### PR TITLE
feat(expenses): mark as refunded to exclude from totals and insights

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -44,22 +44,26 @@ service cloud.firestore {
             ['name', 'amount', 'date', 'categoryId', 'createdAt', 'updatedAt']
           )
           && request.resource.data.keys().hasOnly(
-            ['name', 'amount', 'date', 'categoryId', 'recurringId',
+            ['name', 'amount', 'date', 'categoryId', 'recurringId', 'refunded',
              'createdAt', 'updatedAt']
           )
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
           && isIsoDate(request.resource.data.date)
-          && isNonEmptyString(request.resource.data.categoryId, 64);
+          && isNonEmptyString(request.resource.data.categoryId, 64)
+          && (!('refunded' in request.resource.data)
+              || request.resource.data.refunded is bool);
 
         allow update: if isOwner(userId)
           && request.resource.data.diff(resource.data).affectedKeys()
               .hasOnly(['name', 'amount', 'date', 'categoryId',
-                        'recurringId', 'updatedAt'])
+                        'recurringId', 'refunded', 'updatedAt'])
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
           && isIsoDate(request.resource.data.date)
-          && isNonEmptyString(request.resource.data.categoryId, 64);
+          && isNonEmptyString(request.resource.data.categoryId, 64)
+          && (!('refunded' in request.resource.data)
+              || request.resource.data.refunded is bool);
 
         allow delete: if isOwner(userId);
       }

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -82,6 +82,7 @@ const ExpenseFilters = ({
               <DropdownMenuCheckboxItem
                 key={category.id}
                 checked={value.categoryIds.includes(category.id)}
+                onSelect={(e) => e.preventDefault()}
                 onCheckedChange={(checked) =>
                   toggleCategory(category.id, checked === true)
                 }

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import { CalendarIcon, Filter, Search, X } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "./ui/button";
@@ -13,6 +12,7 @@ import {
 } from "./ui/dropdown-menu";
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import MonthSwitcher from "./MonthSwitcher";
 import type { Category } from "../types/expense";
 
 export interface ExpenseFiltersState {
@@ -46,12 +46,6 @@ const ExpenseFilters = ({
         ? (categories.find((c) => c.id === value.categoryIds[0])?.name ??
           "1 category")
         : `${value.categoryIds.length} categories`;
-
-  const rangeLabel = value.dateRange?.from
-    ? value.dateRange.to
-      ? `${format(value.dateRange.from, "MMM d")} → ${format(value.dateRange.to, "MMM d")}`
-      : format(value.dateRange.from, "MMM d, yyyy")
-    : "Any date";
 
   const hasActive =
     value.search.length > 0 ||
@@ -99,10 +93,15 @@ const ExpenseFilters = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
+      <MonthSwitcher
+        value={value.dateRange}
+        onChange={(range) => onChange({ ...value, dateRange: range })}
+      />
+
       <Popover>
         <PopoverTrigger asChild>
-          <Button variant="outline" className="justify-start">
-            <CalendarIcon className="h-4 w-4" /> {rangeLabel}
+          <Button variant="ghost" size="icon" aria-label="Custom date range">
+            <CalendarIcon className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -53,8 +53,8 @@ const ExpenseFilters = ({
     !!value.dateRange;
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-      <div className="relative flex-1">
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+      <div className="relative lg:flex-1 lg:min-w-[240px]">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
           className="pl-9"
@@ -64,68 +64,70 @@ const ExpenseFilters = ({
         />
       </div>
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="justify-start">
-            <Filter className="h-4 w-4" /> {activeCategoryLabel}
+      <div className="flex flex-wrap items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="justify-start">
+              <Filter className="h-4 w-4" /> {activeCategoryLabel}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-56">
+            <DropdownMenuLabel>Filter by category</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {categories.length === 0 ? (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                No categories yet
+              </div>
+            ) : (
+              categories.map((category) => (
+                <DropdownMenuCheckboxItem
+                  key={category.id}
+                  checked={value.categoryIds.includes(category.id)}
+                  onSelect={(e) => e.preventDefault()}
+                  onCheckedChange={(checked) =>
+                    toggleCategory(category.id, checked === true)
+                  }
+                >
+                  {category.name}
+                </DropdownMenuCheckboxItem>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <MonthSwitcher
+          value={value.dateRange}
+          onChange={(range) => onChange({ ...value, dateRange: range })}
+        />
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Custom date range">
+              <CalendarIcon className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="range"
+              selected={value.dateRange}
+              onSelect={(range) => onChange({ ...value, dateRange: range })}
+              numberOfMonths={2}
+            />
+          </PopoverContent>
+        </Popover>
+
+        {hasActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              onChange({ search: "", categoryIds: [], dateRange: undefined })
+            }
+          >
+            <X className="h-4 w-4" /> Clear
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
-          <DropdownMenuLabel>Filter by category</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {categories.length === 0 ? (
-            <div className="px-2 py-1.5 text-sm text-muted-foreground">
-              No categories yet
-            </div>
-          ) : (
-            categories.map((category) => (
-              <DropdownMenuCheckboxItem
-                key={category.id}
-                checked={value.categoryIds.includes(category.id)}
-                onSelect={(e) => e.preventDefault()}
-                onCheckedChange={(checked) =>
-                  toggleCategory(category.id, checked === true)
-                }
-              >
-                {category.name}
-              </DropdownMenuCheckboxItem>
-            ))
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <MonthSwitcher
-        value={value.dateRange}
-        onChange={(range) => onChange({ ...value, dateRange: range })}
-      />
-
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button variant="ghost" size="icon" aria-label="Custom date range">
-            <CalendarIcon className="h-4 w-4" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            mode="range"
-            selected={value.dateRange}
-            onSelect={(range) => onChange({ ...value, dateRange: range })}
-            numberOfMonths={2}
-          />
-        </PopoverContent>
-      </Popover>
-
-      {hasActive && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() =>
-            onChange({ search: "", categoryIds: [], dateRange: undefined })
-          }
-        >
-          <X className="h-4 w-4" /> Clear
-        </Button>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/MonthSwitcher.tsx
+++ b/src/components/MonthSwitcher.tsx
@@ -1,6 +1,7 @@
-import { addMonths, endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import { addMonths, endOfMonth, format, startOfMonth } from "date-fns";
 import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
 import type { DateRange } from "react-day-picker";
+import { describePeriod } from "../lib/describePeriod";
 import { Button } from "./ui/button";
 
 interface MonthSwitcherProps {
@@ -8,26 +9,13 @@ interface MonthSwitcherProps {
   onChange: (next: DateRange | undefined) => void;
 }
 
-const describe = (
-  value: DateRange | undefined
-): { mode: "month" | "custom" | "all"; month: Date | null } => {
-  if (!value?.from) return { mode: "all", month: null };
-  if (!value.to) return { mode: "custom", month: null };
-  const start = startOfMonth(value.from);
-  const end = endOfMonth(value.from);
-  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
-    return { mode: "month", month: start };
-  }
-  return { mode: "custom", month: null };
-};
-
 const rangeForMonth = (anchor: Date): DateRange => ({
   from: startOfMonth(anchor),
   to: endOfMonth(anchor),
 });
 
 const MonthSwitcher = ({ value, onChange }: MonthSwitcherProps) => {
-  const state = describe(value);
+  const state = describePeriod(value);
   const label =
     state.mode === "month"
       ? format(state.month!, "MMMM yyyy")

--- a/src/components/MonthSwitcher.tsx
+++ b/src/components/MonthSwitcher.tsx
@@ -1,0 +1,105 @@
+import { addMonths, endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import type { DateRange } from "react-day-picker";
+import { Button } from "./ui/button";
+
+interface MonthSwitcherProps {
+  value: DateRange | undefined;
+  onChange: (next: DateRange | undefined) => void;
+}
+
+const describe = (
+  value: DateRange | undefined
+): { mode: "month" | "custom" | "all"; month: Date | null } => {
+  if (!value?.from) return { mode: "all", month: null };
+  if (!value.to) return { mode: "custom", month: null };
+  const start = startOfMonth(value.from);
+  const end = endOfMonth(value.from);
+  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
+    return { mode: "month", month: start };
+  }
+  return { mode: "custom", month: null };
+};
+
+const rangeForMonth = (anchor: Date): DateRange => ({
+  from: startOfMonth(anchor),
+  to: endOfMonth(anchor),
+});
+
+const MonthSwitcher = ({ value, onChange }: MonthSwitcherProps) => {
+  const state = describe(value);
+  const label =
+    state.mode === "month"
+      ? format(state.month!, "MMMM yyyy")
+      : state.mode === "custom"
+      ? "Custom range"
+      : "All time";
+
+  const goPrev = () => {
+    const anchor =
+      state.mode === "month"
+        ? addMonths(state.month!, -1)
+        : addMonths(new Date(), -1);
+    onChange(rangeForMonth(anchor));
+  };
+  const goNext = () => {
+    const anchor =
+      state.mode === "month"
+        ? addMonths(state.month!, 1)
+        : new Date();
+    onChange(rangeForMonth(anchor));
+  };
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <div className="inline-flex items-center rounded-md border border-border bg-background">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 rounded-r-none"
+          onClick={goPrev}
+          disabled={state.mode === "custom"}
+          aria-label="Previous month"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="px-3 text-sm font-medium tabular-nums min-w-[108px] text-center">
+          {label}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 rounded-l-none"
+          onClick={goNext}
+          disabled={state.mode === "custom"}
+          aria-label="Next month"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+      {state.mode === "all" ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onChange(rangeForMonth(new Date()))}
+        >
+          <CalendarDays className="h-4 w-4" /> This month
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onChange(undefined)}
+        >
+          All time
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default MonthSwitcher;

--- a/src/components/PromoteRecurringDialog.tsx
+++ b/src/components/PromoteRecurringDialog.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import DatePicker from "./DatePicker";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Label } from "./ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import type { Expense, RecurringFrequency } from "../types/expense";
+
+interface PromoteRecurringDialogProps {
+  expense: Expense | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (values: {
+    frequency: RecurringFrequency;
+    endDate?: string;
+  }) => Promise<void> | void;
+}
+
+const PromoteRecurringDialog = ({
+  expense,
+  open,
+  onOpenChange,
+  onConfirm,
+}: PromoteRecurringDialogProps) => {
+  const [frequency, setFrequency] = useState<RecurringFrequency>("monthly");
+  const [endDate, setEndDate] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setFrequency("monthly");
+      setEndDate("");
+    }
+  }, [open]);
+
+  const handleConfirm = async () => {
+    if (!expense) return;
+    setSubmitting(true);
+    try {
+      await onConfirm({ frequency, endDate: endDate || undefined });
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Make &quot;{expense?.name}&quot; recurring
+          </DialogTitle>
+          <DialogDescription>
+            The existing expense on {expense?.date} becomes the first
+            occurrence. Future occurrences are generated on login.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Frequency</Label>
+            <Select
+              value={frequency}
+              onValueChange={(v) => setFrequency(v as RecurringFrequency)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="weekly">Weekly</SelectItem>
+                <SelectItem value="monthly">Monthly</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="promote-end">End date (optional)</Label>
+            <DatePicker
+              id="promote-end"
+              value={endDate}
+              onChange={setEndDate}
+              placeholder="No end date"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting || !expense}
+          >
+            Make recurring
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PromoteRecurringDialog;

--- a/src/components/Totalizers.tsx
+++ b/src/components/Totalizers.tsx
@@ -1,8 +1,9 @@
-import { Hash, Sigma, Wallet } from "lucide-react";
+import { Hash, Repeat, Sigma, Wallet } from "lucide-react";
 
 interface TotalizersProps {
   total: number;
   count: number;
+  fixed: number;
 }
 
 const formatCurrency = (value: number) =>
@@ -11,17 +12,18 @@ const formatCurrency = (value: number) =>
     currency: "BRL",
   }).format(value);
 
-const Totalizers = ({ total, count }: TotalizersProps) => {
+const Totalizers = ({ total, count, fixed }: TotalizersProps) => {
   const average = count > 0 ? total / count : 0;
 
   const cards = [
     { label: "Total spent", value: formatCurrency(total), Icon: Wallet },
     { label: "Entries", value: String(count), Icon: Hash },
     { label: "Avg per entry", value: formatCurrency(average), Icon: Sigma },
+    { label: "Fixed", value: formatCurrency(fixed), Icon: Repeat },
   ];
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 w-full">
       {cards.map(({ label, value, Icon }, i) => (
         <div
           key={label}

--- a/src/lib/describePeriod.ts
+++ b/src/lib/describePeriod.ts
@@ -1,0 +1,29 @@
+import { endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import type { DateRange } from "react-day-picker";
+
+export const describePeriod = (
+  value: DateRange | undefined
+): { mode: "month" | "custom" | "all"; month: Date | null; label: string } => {
+  if (!value?.from) return { mode: "all", month: null, label: "All time" };
+  if (!value.to) {
+    return {
+      mode: "custom",
+      month: null,
+      label: format(value.from, "MMM d, yyyy"),
+    };
+  }
+  const start = startOfMonth(value.from);
+  const end = endOfMonth(value.from);
+  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
+    return {
+      mode: "month",
+      month: start,
+      label: format(start, "MMMM yyyy"),
+    };
+  }
+  return {
+    mode: "custom",
+    month: null,
+    label: `${format(value.from, "MMM d")} → ${format(value.to, "MMM d, yyyy")}`,
+  };
+};

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -271,7 +271,17 @@ const Expenses = ({ uid }: ExpensesProps) => {
                   <Pencil className="h-4 w-4" /> Edit
                 </DropdownMenuItem>
                 <DropdownMenuItem
-                  onSelect={() => handleToggleRefunded(row.original)}
+                  onSelect={async () => {
+                    const next = !row.original.refunded;
+                    await updateExpense(uid, row.original.id, {
+                      refunded: next,
+                    });
+                    toast.success(
+                      next
+                        ? `Marked "${row.original.name}" as refunded`
+                        : `Unmarked "${row.original.name}"`
+                    );
+                  }}
                 >
                   <RotateCcw className="h-4 w-4" />{" "}
                   {row.original.refunded
@@ -291,7 +301,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
         ),
       },
     ],
-    [byId]
+    [byId, uid]
   );
 
   const handleCreate = async (values: ExpenseFormResult) => {
@@ -340,14 +350,6 @@ const Expenses = ({ uid }: ExpensesProps) => {
     await deleteExpense(uid, deleting.id);
     toast.success(`Deleted "${deleting.name}"`);
     setDeleting(null);
-  };
-
-  const handleToggleRefunded = async (expense: Expense) => {
-    const next = !expense.refunded;
-    await updateExpense(uid, expense.id, { refunded: next });
-    toast.success(
-      next ? `Marked "${expense.name}" as refunded` : `Unmarked "${expense.name}"`
-    );
   };
 
   const handleBulkDelete = async () => {

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -3,12 +3,14 @@ import {
   RowSelectionState,
   SortingFn,
 } from "@tanstack/react-table";
+import { endOfMonth, startOfMonth } from "date-fns";
 import {
   ArrowUpDown,
   Download,
   MoreHorizontal,
   Pencil,
   Plus,
+  Repeat,
   RotateCcw,
   Trash2,
   Upload,
@@ -26,6 +28,7 @@ import ExpenseFilters, {
 import ExpenseForm, {
   ExpenseFormResult,
 } from "../../components/ExpenseForm";
+import PromoteRecurringDialog from "../../components/PromoteRecurringDialog";
 import Totalizers from "../../components/Totalizers";
 import {
   AlertDialog,
@@ -84,15 +87,19 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const { expenses, loading } = useExpenses(uid);
   const { categories, byId } = useCategories(uid);
 
-  const [filters, setFilters] = useState<ExpenseFiltersState>({
-    search: "",
-    categoryIds: [],
-    dateRange: undefined,
+  const [filters, setFilters] = useState<ExpenseFiltersState>(() => {
+    const now = new Date();
+    return {
+      search: "",
+      categoryIds: [],
+      dateRange: { from: startOfMonth(now), to: endOfMonth(now) },
+    };
   });
 
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<Expense | null>(null);
   const [deleting, setDeleting] = useState<Expense | null>(null);
+  const [promoting, setPromoting] = useState<Expense | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
@@ -131,7 +138,10 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const totals = useMemo(() => {
     const nonRefunded = filtered.filter((e) => !e.refunded);
     const total = nonRefunded.reduce((acc, e) => acc + e.amount, 0);
-    return { total, count: nonRefunded.length };
+    const fixed = nonRefunded
+      .filter((e) => !!e.recurringId)
+      .reduce((acc, e) => acc + e.amount, 0);
+    return { total, count: nonRefunded.length, fixed };
   }, [filtered]);
 
   const selectedIds = useMemo(
@@ -270,6 +280,13 @@ const Expenses = ({ uid }: ExpensesProps) => {
                 >
                   <Pencil className="h-4 w-4" /> Edit
                 </DropdownMenuItem>
+                {!row.original.recurringId && (
+                  <DropdownMenuItem
+                    onSelect={() => setPromoting(row.original)}
+                  >
+                    <Repeat className="h-4 w-4" /> Make recurring
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   onSelect={async () => {
                     const next = !row.original.refunded;
@@ -350,6 +367,24 @@ const Expenses = ({ uid }: ExpensesProps) => {
     await deleteExpense(uid, deleting.id);
     toast.success(`Deleted "${deleting.name}"`);
     setDeleting(null);
+  };
+
+  const handlePromoteRecurring = async (values: {
+    frequency: "weekly" | "monthly";
+    endDate?: string;
+  }) => {
+    if (!promoting) return;
+    const recurringId = await addRecurring(uid, {
+      name: promoting.name,
+      amount: promoting.amount,
+      categoryId: promoting.categoryId,
+      frequency: values.frequency,
+      startDate: promoting.date,
+      endDate: values.endDate,
+    });
+    await updateExpense(uid, promoting.id, { recurringId });
+    toast.success(`"${promoting.name}" is now recurring`);
+    setPromoting(null);
   };
 
   const handleBulkDelete = async () => {
@@ -445,7 +480,11 @@ const Expenses = ({ uid }: ExpensesProps) => {
         </div>
       </div>
 
-      <Totalizers total={totals.total} count={totals.count} />
+      <Totalizers
+        total={totals.total}
+        count={totals.count}
+        fixed={totals.fixed}
+      />
 
       {loading ? (
         <div className="space-y-2">
@@ -551,6 +590,13 @@ const Expenses = ({ uid }: ExpensesProps) => {
         onOpenChange={setImportOpen}
         onImport={handleImport}
         onCreateCategories={handleCreateCategories}
+      />
+
+      <PromoteRecurringDialog
+        expense={promoting}
+        open={!!promoting}
+        onOpenChange={(open) => !open && setPromoting(null)}
+        onConfirm={handlePromoteRecurring}
       />
 
       <SelectionActionBar visible={selectedIds.length > 0}>

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -468,15 +468,24 @@ const Expenses = ({ uid }: ExpensesProps) => {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={handleExport}>
-            <Download className="h-4 w-4" /> Export CSV
+          <Button
+            variant="outline"
+            onClick={handleExport}
+            className="h-9 w-9 p-0 sm:w-auto sm:px-3"
+            aria-label="Export CSV"
+          >
+            <Download className="h-4 w-4" />
+            <span className="hidden sm:inline ml-2">Export CSV</span>
           </Button>
           <Button
             variant="outline"
             onClick={() => setImportOpen(true)}
             disabled={categories.length === 0}
+            className="h-9 w-9 p-0 sm:w-auto sm:px-3"
+            aria-label="Import"
           >
-            <Upload className="h-4 w-4" /> Import
+            <Upload className="h-4 w-4" />
+            <span className="hidden sm:inline ml-2">Import</span>
           </Button>
           <Button
             onClick={() => {
@@ -485,7 +494,9 @@ const Expenses = ({ uid }: ExpensesProps) => {
             }}
             disabled={categories.length === 0}
           >
-            <Plus className="h-4 w-4" /> New expense
+            <Plus className="h-4 w-4" />
+            <span className="sm:hidden ml-1">New</span>
+            <span className="hidden sm:inline ml-1">New expense</span>
           </Button>
         </div>
       </div>

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -9,6 +9,7 @@ import {
   MoreHorizontal,
   Pencil,
   Plus,
+  RotateCcw,
   Trash2,
   Upload,
   X,
@@ -128,8 +129,9 @@ const Expenses = ({ uid }: ExpensesProps) => {
   }, [expenses, byId, filters]);
 
   const totals = useMemo(() => {
-    const total = filtered.reduce((acc, e) => acc + e.amount, 0);
-    return { total, count: filtered.length };
+    const nonRefunded = filtered.filter((e) => !e.refunded);
+    const total = nonRefunded.reduce((acc, e) => acc + e.amount, 0);
+    return { total, count: nonRefunded.length };
   }, [filtered]);
 
   const selectedIds = useMemo(
@@ -175,7 +177,22 @@ const Expenses = ({ uid }: ExpensesProps) => {
           </Button>
         ),
         cell: ({ row }) => (
-          <span className="font-medium">{row.original.name}</span>
+          <span className="inline-flex items-center gap-2">
+            <span
+              className={
+                row.original.refunded
+                  ? "font-medium line-through text-muted-foreground"
+                  : "font-medium"
+              }
+            >
+              {row.original.name}
+            </span>
+            {row.original.refunded && (
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                Refunded
+              </span>
+            )}
+          </span>
         ),
       },
       {
@@ -195,7 +212,13 @@ const Expenses = ({ uid }: ExpensesProps) => {
           </div>
         ),
         cell: ({ row }) => (
-          <div className="text-right font-medium tabular-nums">
+          <div
+            className={
+              row.original.refunded
+                ? "text-right font-medium tabular-nums line-through text-muted-foreground"
+                : "text-right font-medium tabular-nums"
+            }
+          >
             {currency.format(row.original.amount)}
           </div>
         ),
@@ -246,6 +269,14 @@ const Expenses = ({ uid }: ExpensesProps) => {
                   }}
                 >
                   <Pencil className="h-4 w-4" /> Edit
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => handleToggleRefunded(row.original)}
+                >
+                  <RotateCcw className="h-4 w-4" />{" "}
+                  {row.original.refunded
+                    ? "Unmark refunded"
+                    : "Mark as refunded"}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -309,6 +340,14 @@ const Expenses = ({ uid }: ExpensesProps) => {
     await deleteExpense(uid, deleting.id);
     toast.success(`Deleted "${deleting.name}"`);
     setDeleting(null);
+  };
+
+  const handleToggleRefunded = async (expense: Expense) => {
+    const next = !expense.refunded;
+    await updateExpense(uid, expense.id, { refunded: next });
+    toast.success(
+      next ? `Marked "${expense.name}" as refunded` : `Unmarked "${expense.name}"`
+    );
   };
 
   const handleBulkDelete = async () => {

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -198,6 +198,15 @@ const Expenses = ({ uid }: ExpensesProps) => {
             >
               {row.original.name}
             </span>
+            {row.original.recurringId && (
+              <span
+                className="inline-flex items-center text-muted-foreground"
+                title="Recurring"
+                aria-label="Recurring"
+              >
+                <Repeat className="h-3.5 w-3.5" />
+              </span>
+            )}
             {row.original.refunded && (
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                 Refunded

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -30,6 +30,7 @@ import ExpenseForm, {
 } from "../../components/ExpenseForm";
 import PromoteRecurringDialog from "../../components/PromoteRecurringDialog";
 import Totalizers from "../../components/Totalizers";
+import { describePeriod } from "../../lib/describePeriod";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -477,6 +478,17 @@ const Expenses = ({ uid }: ExpensesProps) => {
           >
             <Plus className="h-4 w-4" /> New expense
           </Button>
+        </div>
+      </div>
+
+      <div className="flex items-baseline justify-between gap-2">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">
+            {describePeriod(filters.dateRange).label}
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Reference period for the numbers below
+          </p>
         </div>
       </div>
 

--- a/src/pages/Insights/Insights.test.tsx
+++ b/src/pages/Insights/Insights.test.tsx
@@ -121,4 +121,33 @@ describe("Insights page", () => {
     const trigger = await screen.findByRole("combobox", { name: /period/i });
     expect(trigger).toHaveTextContent(/Last 6 months/i);
   });
+
+  it("excludes refunded expenses from aggregations but keeps the page rendered", async () => {
+    const today = new Date();
+    const y = today.getFullYear();
+    const m = String(today.getMonth() + 1).padStart(2, "0");
+    const within = `${y}-${m}-01`;
+
+    const kept = mkExpense("1", within, 200, "a");
+    kept.name = "Kept expense";
+    const refunded = { ...mkExpense("2", within, 500, "b"), refunded: true };
+    refunded.name = "Refunded expense";
+
+    primeSubscriptions(
+      [kept, refunded],
+      [cat("a", "Food", "#111"), cat("b", "Fun", "#222")]
+    );
+    renderPage();
+
+    // KPIs render (not empty state)
+    expect(await screen.findByText("Top category")).toBeInTheDocument();
+
+    // Refunded expense is absent from the Top 5 list
+    expect(screen.queryByText(/Refunded expense/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Kept expense/)).toBeInTheDocument();
+
+    // Top category reflects the kept expense's category, not the refunded one
+    expect(screen.getAllByText("Food").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Fun")).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/Insights/Insights.tsx
+++ b/src/pages/Insights/Insights.tsx
@@ -40,10 +40,15 @@ interface InsightsProps {
 }
 
 const Insights = ({ uid }: InsightsProps) => {
-  const { expenses, loading: loadingExpenses } = useExpenses(uid);
+  const { expenses: rawExpenses, loading: loadingExpenses } = useExpenses(uid);
   const { categories, byId, loading: loadingCategories } = useCategories(uid);
   const loading = loadingExpenses || loadingCategories;
   const [periodKey, setPeriodKey] = useState<PeriodKey>("last6m");
+
+  const expenses = useMemo(
+    () => rawExpenses.filter((e) => !e.refunded),
+    [rawExpenses]
+  );
 
   const period = useMemo(() => resolvePeriod(periodKey, new Date()), [periodKey]);
   const periodExpenses = useMemo(
@@ -96,7 +101,7 @@ const Insights = ({ uid }: InsightsProps) => {
     );
   }
 
-  if (expenses.length === 0) {
+  if (rawExpenses.length === 0) {
     return (
       <div className="space-y-6">
         {header}

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -49,15 +49,26 @@ export const subscribeExpenses = (
   );
 };
 
+const stripUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+};
+
 export const addExpense = async (
   uid: string,
   input: ExpenseInput
 ): Promise<string> => {
-  const ref = await addDoc(expensesCol(uid), {
-    ...input,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
+  const ref = await addDoc(
+    expensesCol(uid),
+    stripUndefined({
+      ...input,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+  );
   return ref.id;
 };
 
@@ -66,10 +77,13 @@ export const updateExpense = async (
   id: string,
   patch: Partial<ExpenseInput>
 ): Promise<void> => {
-  await updateDoc(doc(expensesCol(uid), id), {
-    ...patch,
-    updatedAt: serverTimestamp(),
-  });
+  await updateDoc(
+    doc(expensesCol(uid), id),
+    stripUndefined({
+      ...patch,
+      updatedAt: serverTimestamp(),
+    })
+  );
 };
 
 export const deleteExpense = async (uid: string, id: string): Promise<void> => {
@@ -118,11 +132,14 @@ export const bulkAddExpenses = async (
     const batch = writeBatch(db);
     for (const input of group) {
       const ref = doc(expensesCol(uid));
-      batch.set(ref, {
-        ...input,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      });
+      batch.set(
+        ref,
+        stripUndefined({
+          ...input,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+      );
     }
     await batch.commit();
   }

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -27,6 +27,7 @@ const mapDoc = (id: string, data: Record<string, unknown>): Expense => ({
   date: data.date as string,
   categoryId: data.categoryId as string,
   recurringId: (data.recurringId as string | undefined) ?? undefined,
+  refunded: (data.refunded as boolean | undefined) ?? false,
   createdAt: data.createdAt as Expense["createdAt"],
   updatedAt: data.updatedAt as Expense["updatedAt"],
 });

--- a/src/services/recurring.ts
+++ b/src/services/recurring.ts
@@ -55,15 +55,26 @@ export const subscribeRecurring = (
   );
 };
 
+const stripUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+};
+
 export const addRecurring = async (
   uid: string,
   input: RecurringInput
 ): Promise<string> => {
-  const ref = await addDoc(recurringCol(uid), {
-    ...input,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
+  const ref = await addDoc(
+    recurringCol(uid),
+    stripUndefined({
+      ...input,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+  );
   return ref.id;
 };
 
@@ -72,10 +83,13 @@ export const updateRecurring = async (
   id: string,
   patch: Partial<RecurringInput> & { lastGeneratedAt?: string }
 ): Promise<void> => {
-  await updateDoc(doc(recurringCol(uid), id), {
-    ...patch,
-    updatedAt: serverTimestamp(),
-  });
+  await updateDoc(
+    doc(recurringCol(uid), id),
+    stripUndefined({
+      ...patch,
+      updatedAt: serverTimestamp(),
+    })
+  );
 };
 
 export const deleteRecurring = async (

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -7,6 +7,7 @@ export interface Expense {
   date: string;
   categoryId: string;
   recurringId?: string;
+  refunded?: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- New `refunded: boolean` field on `Expense` (optional; existing docs read as `false`).
- Row dropdown menu gets a **Mark as refunded / Unmark refunded** toggle between Edit and Delete.
- Refunded rows stay visible with strikethrough on name + amount and a small "Refunded" pill.
- Totalizers on `/expenses` and every `/insights` aggregation (KPIs, monthly trend, donut, top 5, stacked trend) skip refunded rows.
- Firestore rules gain the `refunded` key and `bool` validation.

> **Rules already deployed** to `easy-budget-438713` so the toggle works in the live app.

## Test plan
- [x] `npm run lint && npm run test && npm run build` clean (46 tests, including a new Insights case that asserts refunded rows are excluded from aggregations).
- [x] Rules deployed to production.
- [ ] Manual on `/expenses`: mark a row → strikethrough + badge; Totalizer total and entries drop; refresh persists.
- [ ] Manual on `/insights`: KPIs, monthly bar, donut, top 5, and stacked trend all ignore the refunded row.
- [ ] Unmark → row and aggregations return to normal.