### PR TITLE
feat(expenses): month switcher, fixed KPI, and promote to recurring

### DIFF
--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -82,6 +82,7 @@ const ExpenseFilters = ({
               <DropdownMenuCheckboxItem
                 key={category.id}
                 checked={value.categoryIds.includes(category.id)}
+                onSelect={(e) => e.preventDefault()}
                 onCheckedChange={(checked) =>
                   toggleCategory(category.id, checked === true)
                 }

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import { CalendarIcon, Filter, Search, X } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "./ui/button";
@@ -13,6 +12,7 @@ import {
 } from "./ui/dropdown-menu";
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import MonthSwitcher from "./MonthSwitcher";
 import type { Category } from "../types/expense";
 
 export interface ExpenseFiltersState {
@@ -46,12 +46,6 @@ const ExpenseFilters = ({
         ? (categories.find((c) => c.id === value.categoryIds[0])?.name ??
           "1 category")
         : `${value.categoryIds.length} categories`;
-
-  const rangeLabel = value.dateRange?.from
-    ? value.dateRange.to
-      ? `${format(value.dateRange.from, "MMM d")} → ${format(value.dateRange.to, "MMM d")}`
-      : format(value.dateRange.from, "MMM d, yyyy")
-    : "Any date";
 
   const hasActive =
     value.search.length > 0 ||
@@ -99,10 +93,15 @@ const ExpenseFilters = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
+      <MonthSwitcher
+        value={value.dateRange}
+        onChange={(range) => onChange({ ...value, dateRange: range })}
+      />
+
       <Popover>
         <PopoverTrigger asChild>
-          <Button variant="outline" className="justify-start">
-            <CalendarIcon className="h-4 w-4" /> {rangeLabel}
+          <Button variant="ghost" size="icon" aria-label="Custom date range">
+            <CalendarIcon className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/src/components/MonthSwitcher.tsx
+++ b/src/components/MonthSwitcher.tsx
@@ -1,6 +1,7 @@
-import { addMonths, endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import { addMonths, endOfMonth, format, startOfMonth } from "date-fns";
 import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
 import type { DateRange } from "react-day-picker";
+import { describePeriod } from "../lib/describePeriod";
 import { Button } from "./ui/button";
 
 interface MonthSwitcherProps {
@@ -8,26 +9,13 @@ interface MonthSwitcherProps {
   onChange: (next: DateRange | undefined) => void;
 }
 
-const describe = (
-  value: DateRange | undefined
-): { mode: "month" | "custom" | "all"; month: Date | null } => {
-  if (!value?.from) return { mode: "all", month: null };
-  if (!value.to) return { mode: "custom", month: null };
-  const start = startOfMonth(value.from);
-  const end = endOfMonth(value.from);
-  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
-    return { mode: "month", month: start };
-  }
-  return { mode: "custom", month: null };
-};
-
 const rangeForMonth = (anchor: Date): DateRange => ({
   from: startOfMonth(anchor),
   to: endOfMonth(anchor),
 });
 
 const MonthSwitcher = ({ value, onChange }: MonthSwitcherProps) => {
-  const state = describe(value);
+  const state = describePeriod(value);
   const label =
     state.mode === "month"
       ? format(state.month!, "MMMM yyyy")

--- a/src/components/MonthSwitcher.tsx
+++ b/src/components/MonthSwitcher.tsx
@@ -1,0 +1,105 @@
+import { addMonths, endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import type { DateRange } from "react-day-picker";
+import { Button } from "./ui/button";
+
+interface MonthSwitcherProps {
+  value: DateRange | undefined;
+  onChange: (next: DateRange | undefined) => void;
+}
+
+const describe = (
+  value: DateRange | undefined
+): { mode: "month" | "custom" | "all"; month: Date | null } => {
+  if (!value?.from) return { mode: "all", month: null };
+  if (!value.to) return { mode: "custom", month: null };
+  const start = startOfMonth(value.from);
+  const end = endOfMonth(value.from);
+  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
+    return { mode: "month", month: start };
+  }
+  return { mode: "custom", month: null };
+};
+
+const rangeForMonth = (anchor: Date): DateRange => ({
+  from: startOfMonth(anchor),
+  to: endOfMonth(anchor),
+});
+
+const MonthSwitcher = ({ value, onChange }: MonthSwitcherProps) => {
+  const state = describe(value);
+  const label =
+    state.mode === "month"
+      ? format(state.month!, "MMMM yyyy")
+      : state.mode === "custom"
+      ? "Custom range"
+      : "All time";
+
+  const goPrev = () => {
+    const anchor =
+      state.mode === "month"
+        ? addMonths(state.month!, -1)
+        : addMonths(new Date(), -1);
+    onChange(rangeForMonth(anchor));
+  };
+  const goNext = () => {
+    const anchor =
+      state.mode === "month"
+        ? addMonths(state.month!, 1)
+        : new Date();
+    onChange(rangeForMonth(anchor));
+  };
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      <div className="inline-flex items-center rounded-md border border-border bg-background">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 rounded-r-none"
+          onClick={goPrev}
+          disabled={state.mode === "custom"}
+          aria-label="Previous month"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="px-3 text-sm font-medium tabular-nums min-w-[108px] text-center">
+          {label}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 rounded-l-none"
+          onClick={goNext}
+          disabled={state.mode === "custom"}
+          aria-label="Next month"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+      {state.mode === "all" ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onChange(rangeForMonth(new Date()))}
+        >
+          <CalendarDays className="h-4 w-4" /> This month
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onChange(undefined)}
+        >
+          All time
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default MonthSwitcher;

--- a/src/components/PromoteRecurringDialog.tsx
+++ b/src/components/PromoteRecurringDialog.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import DatePicker from "./DatePicker";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Label } from "./ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import type { Expense, RecurringFrequency } from "../types/expense";
+
+interface PromoteRecurringDialogProps {
+  expense: Expense | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (values: {
+    frequency: RecurringFrequency;
+    endDate?: string;
+  }) => Promise<void> | void;
+}
+
+const PromoteRecurringDialog = ({
+  expense,
+  open,
+  onOpenChange,
+  onConfirm,
+}: PromoteRecurringDialogProps) => {
+  const [frequency, setFrequency] = useState<RecurringFrequency>("monthly");
+  const [endDate, setEndDate] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setFrequency("monthly");
+      setEndDate("");
+    }
+  }, [open]);
+
+  const handleConfirm = async () => {
+    if (!expense) return;
+    setSubmitting(true);
+    try {
+      await onConfirm({ frequency, endDate: endDate || undefined });
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Make &quot;{expense?.name}&quot; recurring
+          </DialogTitle>
+          <DialogDescription>
+            The existing expense on {expense?.date} becomes the first
+            occurrence. Future occurrences are generated on login.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Frequency</Label>
+            <Select
+              value={frequency}
+              onValueChange={(v) => setFrequency(v as RecurringFrequency)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="weekly">Weekly</SelectItem>
+                <SelectItem value="monthly">Monthly</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="promote-end">End date (optional)</Label>
+            <DatePicker
+              id="promote-end"
+              value={endDate}
+              onChange={setEndDate}
+              placeholder="No end date"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting || !expense}
+          >
+            Make recurring
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PromoteRecurringDialog;

--- a/src/components/Totalizers.tsx
+++ b/src/components/Totalizers.tsx
@@ -1,8 +1,9 @@
-import { Hash, Sigma, Wallet } from "lucide-react";
+import { Hash, Repeat, Sigma, Wallet } from "lucide-react";
 
 interface TotalizersProps {
   total: number;
   count: number;
+  fixed: number;
 }
 
 const formatCurrency = (value: number) =>
@@ -11,17 +12,18 @@ const formatCurrency = (value: number) =>
     currency: "BRL",
   }).format(value);
 
-const Totalizers = ({ total, count }: TotalizersProps) => {
+const Totalizers = ({ total, count, fixed }: TotalizersProps) => {
   const average = count > 0 ? total / count : 0;
 
   const cards = [
     { label: "Total spent", value: formatCurrency(total), Icon: Wallet },
     { label: "Entries", value: String(count), Icon: Hash },
     { label: "Avg per entry", value: formatCurrency(average), Icon: Sigma },
+    { label: "Fixed", value: formatCurrency(fixed), Icon: Repeat },
   ];
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 w-full">
       {cards.map(({ label, value, Icon }, i) => (
         <div
           key={label}

--- a/src/lib/describePeriod.ts
+++ b/src/lib/describePeriod.ts
@@ -1,0 +1,29 @@
+import { endOfMonth, format, isSameDay, startOfMonth } from "date-fns";
+import type { DateRange } from "react-day-picker";
+
+export const describePeriod = (
+  value: DateRange | undefined
+): { mode: "month" | "custom" | "all"; month: Date | null; label: string } => {
+  if (!value?.from) return { mode: "all", month: null, label: "All time" };
+  if (!value.to) {
+    return {
+      mode: "custom",
+      month: null,
+      label: format(value.from, "MMM d, yyyy"),
+    };
+  }
+  const start = startOfMonth(value.from);
+  const end = endOfMonth(value.from);
+  if (isSameDay(value.from, start) && isSameDay(value.to, end)) {
+    return {
+      mode: "month",
+      month: start,
+      label: format(start, "MMMM yyyy"),
+    };
+  }
+  return {
+    mode: "custom",
+    month: null,
+    label: `${format(value.from, "MMM d")} → ${format(value.to, "MMM d, yyyy")}`,
+  };
+};

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -3,12 +3,14 @@ import {
   RowSelectionState,
   SortingFn,
 } from "@tanstack/react-table";
+import { endOfMonth, startOfMonth } from "date-fns";
 import {
   ArrowUpDown,
   Download,
   MoreHorizontal,
   Pencil,
   Plus,
+  Repeat,
   RotateCcw,
   Trash2,
   Upload,
@@ -26,6 +28,7 @@ import ExpenseFilters, {
 import ExpenseForm, {
   ExpenseFormResult,
 } from "../../components/ExpenseForm";
+import PromoteRecurringDialog from "../../components/PromoteRecurringDialog";
 import Totalizers from "../../components/Totalizers";
 import {
   AlertDialog,
@@ -84,15 +87,19 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const { expenses, loading } = useExpenses(uid);
   const { categories, byId } = useCategories(uid);
 
-  const [filters, setFilters] = useState<ExpenseFiltersState>({
-    search: "",
-    categoryIds: [],
-    dateRange: undefined,
+  const [filters, setFilters] = useState<ExpenseFiltersState>(() => {
+    const now = new Date();
+    return {
+      search: "",
+      categoryIds: [],
+      dateRange: { from: startOfMonth(now), to: endOfMonth(now) },
+    };
   });
 
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<Expense | null>(null);
   const [deleting, setDeleting] = useState<Expense | null>(null);
+  const [promoting, setPromoting] = useState<Expense | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
@@ -131,7 +138,10 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const totals = useMemo(() => {
     const nonRefunded = filtered.filter((e) => !e.refunded);
     const total = nonRefunded.reduce((acc, e) => acc + e.amount, 0);
-    return { total, count: nonRefunded.length };
+    const fixed = nonRefunded
+      .filter((e) => !!e.recurringId)
+      .reduce((acc, e) => acc + e.amount, 0);
+    return { total, count: nonRefunded.length, fixed };
   }, [filtered]);
 
   const selectedIds = useMemo(
@@ -270,6 +280,13 @@ const Expenses = ({ uid }: ExpensesProps) => {
                 >
                   <Pencil className="h-4 w-4" /> Edit
                 </DropdownMenuItem>
+                {!row.original.recurringId && (
+                  <DropdownMenuItem
+                    onSelect={() => setPromoting(row.original)}
+                  >
+                    <Repeat className="h-4 w-4" /> Make recurring
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   onSelect={async () => {
                     const next = !row.original.refunded;
@@ -350,6 +367,24 @@ const Expenses = ({ uid }: ExpensesProps) => {
     await deleteExpense(uid, deleting.id);
     toast.success(`Deleted "${deleting.name}"`);
     setDeleting(null);
+  };
+
+  const handlePromoteRecurring = async (values: {
+    frequency: "weekly" | "monthly";
+    endDate?: string;
+  }) => {
+    if (!promoting) return;
+    const recurringId = await addRecurring(uid, {
+      name: promoting.name,
+      amount: promoting.amount,
+      categoryId: promoting.categoryId,
+      frequency: values.frequency,
+      startDate: promoting.date,
+      endDate: values.endDate,
+    });
+    await updateExpense(uid, promoting.id, { recurringId });
+    toast.success(`"${promoting.name}" is now recurring`);
+    setPromoting(null);
   };
 
   const handleBulkDelete = async () => {
@@ -445,7 +480,11 @@ const Expenses = ({ uid }: ExpensesProps) => {
         </div>
       </div>
 
-      <Totalizers total={totals.total} count={totals.count} />
+      <Totalizers
+        total={totals.total}
+        count={totals.count}
+        fixed={totals.fixed}
+      />
 
       {loading ? (
         <div className="space-y-2">
@@ -551,6 +590,13 @@ const Expenses = ({ uid }: ExpensesProps) => {
         onOpenChange={setImportOpen}
         onImport={handleImport}
         onCreateCategories={handleCreateCategories}
+      />
+
+      <PromoteRecurringDialog
+        expense={promoting}
+        open={!!promoting}
+        onOpenChange={(open) => !open && setPromoting(null)}
+        onConfirm={handlePromoteRecurring}
       />
 
       <SelectionActionBar visible={selectedIds.length > 0}>

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -198,6 +198,15 @@ const Expenses = ({ uid }: ExpensesProps) => {
             >
               {row.original.name}
             </span>
+            {row.original.recurringId && (
+              <span
+                className="inline-flex items-center text-muted-foreground"
+                title="Recurring"
+                aria-label="Recurring"
+              >
+                <Repeat className="h-3.5 w-3.5" />
+              </span>
+            )}
             {row.original.refunded && (
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
                 Refunded

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -30,6 +30,7 @@ import ExpenseForm, {
 } from "../../components/ExpenseForm";
 import PromoteRecurringDialog from "../../components/PromoteRecurringDialog";
 import Totalizers from "../../components/Totalizers";
+import { describePeriod } from "../../lib/describePeriod";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -477,6 +478,17 @@ const Expenses = ({ uid }: ExpensesProps) => {
           >
             <Plus className="h-4 w-4" /> New expense
           </Button>
+        </div>
+      </div>
+
+      <div className="flex items-baseline justify-between gap-2">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">
+            {describePeriod(filters.dateRange).label}
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            Reference period for the numbers below
+          </p>
         </div>
       </div>
 

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -49,15 +49,26 @@ export const subscribeExpenses = (
   );
 };
 
+const stripUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+};
+
 export const addExpense = async (
   uid: string,
   input: ExpenseInput
 ): Promise<string> => {
-  const ref = await addDoc(expensesCol(uid), {
-    ...input,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
+  const ref = await addDoc(
+    expensesCol(uid),
+    stripUndefined({
+      ...input,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+  );
   return ref.id;
 };
 
@@ -66,10 +77,13 @@ export const updateExpense = async (
   id: string,
   patch: Partial<ExpenseInput>
 ): Promise<void> => {
-  await updateDoc(doc(expensesCol(uid), id), {
-    ...patch,
-    updatedAt: serverTimestamp(),
-  });
+  await updateDoc(
+    doc(expensesCol(uid), id),
+    stripUndefined({
+      ...patch,
+      updatedAt: serverTimestamp(),
+    })
+  );
 };
 
 export const deleteExpense = async (uid: string, id: string): Promise<void> => {
@@ -118,11 +132,14 @@ export const bulkAddExpenses = async (
     const batch = writeBatch(db);
     for (const input of group) {
       const ref = doc(expensesCol(uid));
-      batch.set(ref, {
-        ...input,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-      });
+      batch.set(
+        ref,
+        stripUndefined({
+          ...input,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+      );
     }
     await batch.commit();
   }

--- a/src/services/recurring.ts
+++ b/src/services/recurring.ts
@@ -55,15 +55,26 @@ export const subscribeRecurring = (
   );
 };
 
+const stripUndefined = <T extends Record<string, unknown>>(obj: T): T => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+};
+
 export const addRecurring = async (
   uid: string,
   input: RecurringInput
 ): Promise<string> => {
-  const ref = await addDoc(recurringCol(uid), {
-    ...input,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
+  const ref = await addDoc(
+    recurringCol(uid),
+    stripUndefined({
+      ...input,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+  );
   return ref.id;
 };
 
@@ -72,10 +83,13 @@ export const updateRecurring = async (
   id: string,
   patch: Partial<RecurringInput> & { lastGeneratedAt?: string }
 ): Promise<void> => {
-  await updateDoc(doc(recurringCol(uid), id), {
-    ...patch,
-    updatedAt: serverTimestamp(),
-  });
+  await updateDoc(
+    doc(recurringCol(uid), id),
+    stripUndefined({
+      ...patch,
+      updatedAt: serverTimestamp(),
+    })
+  );
 };
 
 export const deleteRecurring = async (


### PR DESCRIPTION
> Stacked on top of #57 (refund feature). Rebased/retargeted onto `main` once #57 merges.

## Summary
Three coordinated improvements to `/expenses`:

1. **Month switcher** as the primary date control — prev/next arrows, "All time" shortcut, default is the current month on page load. The old date-range calendar is still one click away for custom ranges.
2. **Fixed KPI** (4th card in the Totalizers row) summing expenses whose `recurringId` is set, so you can see fixed-vs-variable at a glance.
3. **Make recurring** action on each row — minimal dialog (frequency + optional end date), creates a Recurring template and links the existing expense as its first occurrence. Future occurrences materialize on the next login via the existing idempotent flow.

## Test plan
- [x] `npm run lint && npm run test && npm run build` clean.
- [ ] Load `/expenses` → filter already reads current month.
- [ ] Prev/next arrows cycle months; "All time" clears; custom-range button still works.
- [ ] Fixed card shows sum of expenses with `recurringId` in the visible range.
- [ ] Row menu: **Make recurring** on a non-recurring row → Monthly → confirms → toast; expense gets `recurringId`; template appears on `/settings`.
- [ ] Menu item hidden when the row is already part of a recurring template.