### PR TITLE
feat(groups): group expenses by occasion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# reCAPTCHA Enterprise site key for Firebase App Check (public — embedded in bundle)
+# 1. Create a key at https://console.cloud.google.com/security/recaptcha (type: Website).
+#    Add production domain(s) and "localhost" under Allowed Domains.
+# 2. Register Firebase App Check: Firebase Console -> App Check -> Apps -> register the
+#    web app with the reCAPTCHA Enterprise provider, referencing the key above.
+# 3. Copy this file to .env.local and set the value below to the site key.
+# 4. In dev, the first run prints a debug token in the browser console; register it in
+#    Firebase Console -> App Check -> Apps -> Manage debug tokens (one-time per machine).
+VITE_RECAPTCHA_SITE_KEY=

--- a/firestore.rules
+++ b/firestore.rules
@@ -44,24 +44,28 @@ service cloud.firestore {
             ['name', 'amount', 'date', 'categoryId', 'createdAt', 'updatedAt']
           )
           && request.resource.data.keys().hasOnly(
-            ['name', 'amount', 'date', 'categoryId', 'recurringId', 'refunded',
-             'createdAt', 'updatedAt']
+            ['name', 'amount', 'date', 'categoryId', 'groupId', 'recurringId',
+             'refunded', 'createdAt', 'updatedAt']
           )
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
           && isIsoDate(request.resource.data.date)
           && isNonEmptyString(request.resource.data.categoryId, 64)
+          && (!('groupId' in request.resource.data)
+              || isNonEmptyString(request.resource.data.groupId, 64))
           && (!('refunded' in request.resource.data)
               || request.resource.data.refunded is bool);
 
         allow update: if isOwner(userId)
           && request.resource.data.diff(resource.data).affectedKeys()
-              .hasOnly(['name', 'amount', 'date', 'categoryId',
+              .hasOnly(['name', 'amount', 'date', 'categoryId', 'groupId',
                         'recurringId', 'refunded', 'updatedAt'])
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
           && isIsoDate(request.resource.data.date)
           && isNonEmptyString(request.resource.data.categoryId, 64)
+          && (!('groupId' in request.resource.data)
+              || isNonEmptyString(request.resource.data.groupId, 64))
           && (!('refunded' in request.resource.data)
               || request.resource.data.refunded is bool);
 
@@ -79,6 +83,30 @@ service cloud.firestore {
             ['name', 'color', 'icon', 'order', 'createdAt']
           )
           && isNonEmptyString(request.resource.data.name, 64)
+          && request.resource.data.color is string
+          && request.resource.data.color.matches('^#[0-9a-fA-F]{6}$')
+          && isNonEmptyString(request.resource.data.icon, 64)
+          && request.resource.data.order is int
+          && request.resource.data.order >= 0;
+
+        allow update: if isOwner(userId)
+          && request.resource.data.diff(resource.data).affectedKeys()
+              .hasOnly(['name', 'color', 'icon', 'order']);
+
+        allow delete: if isOwner(userId);
+      }
+
+      match /groups/{groupId} {
+        allow read: if isOwner(userId);
+
+        allow create: if isOwner(userId)
+          && request.resource.data.keys().hasAll(
+            ['name', 'color', 'icon', 'order', 'createdAt']
+          )
+          && request.resource.data.keys().hasOnly(
+            ['name', 'color', 'icon', 'order', 'createdAt']
+          )
+          && isNonEmptyString(request.resource.data.name, 80)
           && request.resource.data.color is string
           && request.resource.data.color.matches('^#[0-9a-fA-F]{6}$')
           && isNonEmptyString(request.resource.data.icon, 64)

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://www.google.com/recaptcha/enterprise.js?render=6LcvhsMsAAAAAKsyzo84apTBdvFgfHudtwzO4GEy"></script>
     <title>Easy Budget</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { useLoading } from "./contexts/LoadingContext";
 import Auth from "./pages/Auth";
 import Categories from "./pages/Categories";
 import Expenses from "./pages/Expenses";
+import GroupDetail from "./pages/GroupDetail";
+import Groups from "./pages/Groups";
 import Insights from "./pages/Insights";
 import Settings from "./pages/Settings";
 import { auth } from "./services/firebase";
@@ -56,6 +58,11 @@ function App() {
             <Route path="/expenses" element={<Expenses uid={user.uid} />} />
             <Route path="/insights" element={<Insights uid={user.uid} />} />
             <Route path="/categories" element={<Categories uid={user.uid} />} />
+            <Route path="/groups" element={<Groups uid={user.uid} />} />
+            <Route
+              path="/groups/:id"
+              element={<GroupDetail uid={user.uid} />}
+            />
             <Route path="/settings" element={<Settings uid={user.uid} />} />
             <Route path="*" element={<Navigate to="/expenses" replace />} />
           </Route>

--- a/src/components/DeleteGroupDialog.tsx
+++ b/src/components/DeleteGroupDialog.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import type { Group } from "../types/expense";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Label } from "./ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+
+export type DeleteGroupAction =
+  | { action: "unset" }
+  | { action: "reassign"; reassignToId: string };
+
+interface DeleteGroupDialogProps {
+  open: boolean;
+  group: Group | null;
+  otherGroups: Group[];
+  expenseCount: number;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (args: DeleteGroupAction) => Promise<void> | void;
+}
+
+const DeleteGroupDialog = ({
+  open,
+  group,
+  otherGroups,
+  expenseCount,
+  onOpenChange,
+  onConfirm,
+}: DeleteGroupDialogProps) => {
+  const [mode, setMode] = useState<"unset" | "reassign">("unset");
+  const [reassignTo, setReassignTo] = useState<string | undefined>(
+    otherGroups[0]?.id
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setMode("unset");
+      setReassignTo(otherGroups[0]?.id);
+    }
+  }, [open, otherGroups]);
+
+  const hasExpenses = expenseCount > 0;
+  const canConfirm =
+    !hasExpenses ||
+    mode === "unset" ||
+    (mode === "reassign" && !!reassignTo && otherGroups.length > 0);
+
+  const handleConfirm = async () => {
+    if (!canConfirm) return;
+    setSubmitting(true);
+    try {
+      if (!hasExpenses || mode === "unset") {
+        await onConfirm({ action: "unset" });
+      } else {
+        await onConfirm({ action: "reassign", reassignToId: reassignTo! });
+      }
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete group</DialogTitle>
+          <DialogDescription>
+            {group ? (
+              <>
+                Remove <strong>{group.name}</strong>?{" "}
+                {hasExpenses
+                  ? `${expenseCount} expense${
+                      expenseCount === 1 ? "" : "s"
+                    } belong to this group. Choose what to do with them.`
+                  : "This group is not used by any expense."}
+              </>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {hasExpenses && (
+          <div className="space-y-3">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="delete-group-mode"
+                value="unset"
+                checked={mode === "unset"}
+                onChange={() => setMode("unset")}
+                className="mt-1"
+              />
+              <span className="text-sm">
+                <span className="font-medium">Unset group on these expenses</span>
+                <span className="block text-muted-foreground">
+                  Keep the expenses — they just won’t belong to any group.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="delete-group-mode"
+                value="reassign"
+                checked={mode === "reassign"}
+                onChange={() => setMode("reassign")}
+                disabled={otherGroups.length === 0}
+                className="mt-1"
+              />
+              <span className="text-sm flex-1">
+                <span className="font-medium">Move them to another group</span>
+                {otherGroups.length === 0 ? (
+                  <span className="block text-muted-foreground">
+                    No other groups exist yet.
+                  </span>
+                ) : (
+                  <span className="block mt-2">
+                    <Label htmlFor="reassign-group" className="sr-only">
+                      Reassign to
+                    </Label>
+                    <Select
+                      value={reassignTo}
+                      onValueChange={setReassignTo}
+                      disabled={mode !== "reassign"}
+                    >
+                      <SelectTrigger id="reassign-group">
+                        <SelectValue placeholder="Pick a group" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {otherGroups.map((g) => (
+                          <SelectItem key={g.id} value={g.id}>
+                            {g.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </span>
+                )}
+              </span>
+            </label>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!canConfirm || submitting}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DeleteGroupDialog;

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -1,4 +1,4 @@
-import { CalendarIcon, Filter, Search, X } from "lucide-react";
+import { CalendarIcon, Filter, Search, Users, X } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "./ui/button";
 import { Calendar } from "./ui/calendar";
@@ -13,22 +13,27 @@ import {
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import MonthSwitcher from "./MonthSwitcher";
-import type { Category } from "../types/expense";
+import type { Category, Group } from "../types/expense";
+
+export const NO_GROUP_FILTER = "__none__";
 
 export interface ExpenseFiltersState {
   search: string;
   categoryIds: string[];
+  groupIds: string[];
   dateRange: DateRange | undefined;
 }
 
 interface ExpenseFiltersProps {
   categories: Category[];
+  groups?: Group[];
   value: ExpenseFiltersState;
   onChange: (next: ExpenseFiltersState) => void;
 }
 
 const ExpenseFilters = ({
   categories,
+  groups,
   value,
   onChange,
 }: ExpenseFiltersProps) => {
@@ -39,6 +44,13 @@ const ExpenseFilters = ({
     onChange({ ...value, categoryIds: next });
   };
 
+  const toggleGroup = (id: string, checked: boolean) => {
+    const next = checked
+      ? [...value.groupIds, id]
+      : value.groupIds.filter((x) => x !== id);
+    onChange({ ...value, groupIds: next });
+  };
+
   const activeCategoryLabel =
     value.categoryIds.length === 0
       ? "All categories"
@@ -47,9 +59,23 @@ const ExpenseFilters = ({
           "1 category")
         : `${value.categoryIds.length} categories`;
 
+  const groupNameFor = (id: string) => {
+    if (id === NO_GROUP_FILTER) return "No group";
+    return groups?.find((g) => g.id === id)?.name ?? "1 group";
+  };
+  const activeGroupLabel =
+    value.groupIds.length === 0
+      ? "All groups"
+      : value.groupIds.length === 1
+        ? groupNameFor(value.groupIds[0])
+        : `${value.groupIds.length} groups`;
+
+  const hasGroupsUi = !!groups;
+
   const hasActive =
     value.search.length > 0 ||
     value.categoryIds.length > 0 ||
+    value.groupIds.length > 0 ||
     !!value.dateRange;
 
   return (
@@ -95,6 +121,47 @@ const ExpenseFilters = ({
           </DropdownMenuContent>
         </DropdownMenu>
 
+        {hasGroupsUi && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="justify-start">
+                <Users className="h-4 w-4" /> {activeGroupLabel}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              <DropdownMenuLabel>Filter by group</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuCheckboxItem
+                checked={value.groupIds.includes(NO_GROUP_FILTER)}
+                onSelect={(e) => e.preventDefault()}
+                onCheckedChange={(checked) =>
+                  toggleGroup(NO_GROUP_FILTER, checked === true)
+                }
+              >
+                <span className="italic text-muted-foreground">No group</span>
+              </DropdownMenuCheckboxItem>
+              {groups!.length === 0 ? (
+                <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                  No groups yet
+                </div>
+              ) : (
+                groups!.map((group) => (
+                  <DropdownMenuCheckboxItem
+                    key={group.id}
+                    checked={value.groupIds.includes(group.id)}
+                    onSelect={(e) => e.preventDefault()}
+                    onCheckedChange={(checked) =>
+                      toggleGroup(group.id, checked === true)
+                    }
+                  >
+                    {group.name}
+                  </DropdownMenuCheckboxItem>
+                ))
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
         <MonthSwitcher
           value={value.dateRange}
           onChange={(range) => onChange({ ...value, dateRange: range })}
@@ -121,7 +188,12 @@ const ExpenseFilters = ({
             variant="ghost"
             size="sm"
             onClick={() =>
-              onChange({ search: "", categoryIds: [], dateRange: undefined })
+              onChange({
+                search: "",
+                categoryIds: [],
+                groupIds: [],
+                dateRange: undefined,
+              })
             }
           >
             <X className="h-4 w-4" /> Clear

--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -23,7 +23,7 @@ import {
   SelectValue,
 } from "./ui/select";
 import { Switch } from "./ui/switch";
-import type { Category, RecurringFrequency } from "../types/expense";
+import type { Category, Group, RecurringFrequency } from "../types/expense";
 
 const schema = z
   .object({
@@ -33,6 +33,7 @@ const schema = z
       .positive("Amount must be greater than zero"),
     date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Pick a date"),
     categoryId: z.string().min(1, "Pick a category"),
+    groupId: z.string().optional(),
     recurring: z.boolean(),
     frequency: z.enum(["weekly", "monthly"]).optional(),
     endDate: z
@@ -65,6 +66,7 @@ export interface ExpenseFormResult {
   amount: number;
   date: string;
   categoryId: string;
+  groupId?: string;
   recurring?: {
     frequency: RecurringFrequency;
     endDate?: string;
@@ -76,11 +78,13 @@ interface ExpenseFormProps {
   title: string;
   submitLabel: string;
   categories: Category[];
+  groups?: Group[];
   initialValue?: {
     name: string;
     amount: number;
     date: string;
     categoryId: string;
+    groupId?: string;
   };
   allowRecurring?: boolean;
   onSubmit: (values: ExpenseFormResult) => Promise<void> | void;
@@ -100,6 +104,7 @@ const ExpenseForm = ({
   title,
   submitLabel,
   categories,
+  groups,
   initialValue,
   allowRecurring = true,
   onSubmit,
@@ -110,6 +115,7 @@ const ExpenseForm = ({
     amount: 0,
     date: today(),
     categoryId: categories[0]?.id ?? "",
+    groupId: "",
     recurring: false,
     frequency: "monthly",
     endDate: "",
@@ -128,7 +134,9 @@ const ExpenseForm = ({
   }, [open, initialValue, categories]);
 
   const categoryId = form.watch("categoryId");
+  const groupId = form.watch("groupId");
   const recurring = form.watch("recurring");
+  const hasGroups = !!groups && groups.length > 0;
 
   const handleSubmit = form.handleSubmit(async (values) => {
     const result: ExpenseFormResult = {
@@ -136,6 +144,7 @@ const ExpenseForm = ({
       amount: values.amount,
       date: values.date,
       categoryId: values.categoryId,
+      groupId: values.groupId ? values.groupId : undefined,
     };
     if (values.recurring && values.frequency) {
       result.recurring = {
@@ -226,6 +235,32 @@ const ExpenseForm = ({
               </p>
             )}
           </div>
+
+          {hasGroups && (
+            <div className="space-y-2">
+              <Label>Group (optional)</Label>
+              <Select
+                value={groupId || "none"}
+                onValueChange={(v) =>
+                  form.setValue("groupId", v === "none" ? "" : v, {
+                    shouldValidate: true,
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No group" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No group</SelectItem>
+                  {groups!.map((g) => (
+                    <SelectItem key={g.id} value={g.id}>
+                      {g.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
 
           {allowRecurring && (
             <div className="rounded-md border border-border p-3 space-y-3">

--- a/src/components/GroupForm.test.tsx
+++ b/src/components/GroupForm.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import GroupForm from "./GroupForm";
+
+describe("GroupForm", () => {
+  it("shows validation error when name is empty", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <GroupForm
+        open
+        title="New group"
+        submitLabel="Create"
+        onSubmit={onSubmit}
+        onOpenChange={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a name longer than 80 characters", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <GroupForm
+        open
+        title="New group"
+        submitLabel="Create"
+        onSubmit={onSubmit}
+        onOpenChange={() => {}}
+      />
+    );
+
+    const input = screen.getByLabelText("Name");
+    fireEvent.change(input, { target: { value: "x".repeat(81) } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    // Give the form a tick to process validation.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits with { name, color, icon } when valid", async () => {
+    const onSubmit = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <GroupForm
+        open
+        title="New group"
+        submitLabel="Create"
+        onSubmit={onSubmit}
+        onOpenChange={onOpenChange}
+      />
+    );
+
+    const input = screen.getByLabelText("Name");
+    fireEvent.change(input, { target: { value: "Japan Trip" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const values = onSubmit.mock.calls[0][0];
+    expect(values.name).toBe("Japan Trip");
+    expect(values.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(values.icon.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/GroupForm.tsx
+++ b/src/components/GroupForm.tsx
@@ -1,0 +1,169 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Check } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { cn } from "../lib/utils";
+import { AVAILABLE_ICONS, CategoryIcon } from "./CategoryIcon";
+import { COLOR_PALETTE } from "../lib/categoryPalette";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+const schema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(80),
+  color: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/, "Color must be a hex value"),
+  icon: z.string().min(1, "Pick an icon"),
+});
+
+export type GroupFormValues = z.infer<typeof schema>;
+
+interface GroupFormProps {
+  open: boolean;
+  initialValue?: Partial<GroupFormValues>;
+  title: string;
+  submitLabel: string;
+  onSubmit: (values: GroupFormValues) => Promise<void> | void;
+  onOpenChange: (open: boolean) => void;
+}
+
+const DEFAULTS: GroupFormValues = {
+  name: "",
+  color: COLOR_PALETTE[0],
+  icon: AVAILABLE_ICONS[0],
+};
+
+const GroupForm = ({
+  open,
+  initialValue,
+  title,
+  submitLabel,
+  onSubmit,
+  onOpenChange,
+}: GroupFormProps) => {
+  const form = useForm<GroupFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { ...DEFAULTS, ...initialValue },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ ...DEFAULTS, ...initialValue });
+    }
+  }, [open, initialValue, form]);
+
+  const color = form.watch("color");
+  const icon = form.watch("icon");
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await onSubmit(values);
+    onOpenChange(false);
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Group expenses by occasion — a trip, an event, a project.
+          </DialogDescription>
+        </DialogHeader>
+        <form id="group-form" onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="group-name">Name</Label>
+            <Input
+              id="group-name"
+              placeholder="e.g. Japan Trip"
+              {...form.register("name")}
+            />
+            {form.formState.errors.name && (
+              <p className="text-xs text-destructive">
+                {form.formState.errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <div className="flex flex-wrap gap-2">
+              {COLOR_PALETTE.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() =>
+                    form.setValue("color", option, { shouldValidate: true })
+                  }
+                  className={cn(
+                    "h-8 w-8 rounded-full border-2 flex items-center justify-center transition",
+                    color === option
+                      ? "border-foreground scale-110"
+                      : "border-transparent hover:scale-105"
+                  )}
+                  style={{ backgroundColor: option }}
+                  aria-label={`Color ${option}`}
+                >
+                  {color === option && (
+                    <Check className="h-4 w-4 text-white drop-shadow" />
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Icon</Label>
+            <div className="grid grid-cols-6 gap-2 sm:grid-cols-9">
+              {AVAILABLE_ICONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() =>
+                    form.setValue("icon", option, { shouldValidate: true })
+                  }
+                  className={cn(
+                    "h-9 w-9 rounded-md border flex items-center justify-center transition",
+                    icon === option
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border text-muted-foreground hover:bg-muted"
+                  )}
+                  aria-label={`Icon ${option}`}
+                >
+                  <CategoryIcon name={option} className="h-4 w-4" />
+                </button>
+              ))}
+            </div>
+          </div>
+        </form>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="group-form"
+            disabled={form.formState.isSubmitting}
+          >
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default GroupForm;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Folder, Receipt, Settings } from "lucide-react";
+import { BarChart3, Folder, Receipt, Settings, Users } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import Logo from "./Logo";
 import { cn } from "../lib/utils";
@@ -7,6 +7,7 @@ const NAV = [
   { to: "/expenses", label: "Expenses", icon: Receipt },
   { to: "/insights", label: "Insights", icon: BarChart3 },
   { to: "/categories", label: "Categories", icon: Folder },
+  { to: "/groups", label: "Groups", icon: Users },
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 

--- a/src/features/insights/GroupBreakdownChart.tsx
+++ b/src/features/insights/GroupBreakdownChart.tsx
@@ -1,0 +1,72 @@
+import { Cell, Pie, PieChart } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { formatBRL } from "./formatBRL";
+import type { GroupTotal } from "./aggregate";
+
+interface GroupBreakdownChartProps {
+  data: GroupTotal[];
+}
+
+const GroupBreakdownChart = ({ data }: GroupBreakdownChartProps) => {
+  const config: ChartConfig = Object.fromEntries(
+    data.map((d) => [d.groupId, { label: d.name, color: d.color }])
+  );
+  const grand = data.reduce((s, d) => s + d.total, 0);
+
+  return (
+    <div className="flex flex-col lg:flex-row items-center gap-4">
+      <ChartContainer
+        config={config}
+        className="aspect-square h-[240px] w-[240px] shrink-0"
+      >
+        <PieChart>
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                hideLabel
+                valueFormatter={(v) => formatBRL(v)}
+              />
+            }
+          />
+          <Pie
+            data={data}
+            dataKey="total"
+            nameKey="name"
+            innerRadius={60}
+            outerRadius={100}
+            paddingAngle={2}
+            stroke="none"
+          >
+            {data.map((d) => (
+              <Cell key={d.groupId} fill={d.color} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+      <ul className="flex-1 space-y-2 w-full">
+        {data.map((d) => (
+          <li key={d.groupId} className="flex items-center gap-3 text-sm">
+            <span
+              className="h-2.5 w-2.5 rounded-[3px] shrink-0"
+              style={{ backgroundColor: d.color }}
+            />
+            <span className="flex-1 truncate">{d.name}</span>
+            <span className="font-mono font-medium tabular-nums">
+              {formatBRL(d.total)}
+            </span>
+            <span className="w-12 text-right text-muted-foreground tabular-nums">
+              {grand > 0 ? `${Math.round(d.pct * 100)}%` : "—"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default GroupBreakdownChart;

--- a/src/features/insights/aggregate.test.ts
+++ b/src/features/insights/aggregate.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { Category, Expense } from "@/types/expense";
+import type { Category, Expense, Group } from "@/types/expense";
 import {
   computeKpis,
   filterByPeriod,
   resolvePeriod,
   sumByCategory,
+  sumByGroup,
   sumByMonth,
   sumByMonthAndCategory,
   topExpenses,
@@ -17,15 +18,26 @@ const mkExpense = (
   date: string,
   amount: number,
   categoryId: string,
-  name = "X"
+  name = "X",
+  groupId?: string
 ): Expense => ({
   id,
   name,
   amount,
   date,
   categoryId,
+  groupId,
   createdAt: ts,
   updatedAt: ts,
+});
+
+const grp = (id: string, name: string, color: string): Group => ({
+  id,
+  name,
+  color,
+  icon: "Package",
+  order: 0,
+  createdAt: ts,
 });
 
 const cat = (id: string, name: string, color: string): Category => ({
@@ -144,6 +156,43 @@ describe("sumByMonthAndCategory", () => {
       { month: "2026-03", a: 100, b: 0 },
       { month: "2026-04", a: 0, b: 40 },
     ]);
+  });
+});
+
+describe("sumByGroup", () => {
+  const groups = [
+    grp("g1", "Japan", "#111"),
+    grp("g2", "Birthday", "#222"),
+    grp("g3", "Empty", "#333"),
+  ];
+
+  it("aggregates and skips ungrouped expenses, sorted by total desc", () => {
+    const expenses = [
+      mkExpense("1", "2026-04-01", 30, "a", "a", "g1"),
+      mkExpense("2", "2026-04-02", 70, "a", "b", "g2"),
+      mkExpense("3", "2026-04-03", 20, "a", "c", "g1"),
+      mkExpense("4", "2026-04-04", 999, "a", "ungrouped"),
+    ];
+    const rows = sumByGroup(expenses, groups);
+    expect(rows).toEqual([
+      { groupId: "g2", name: "Birthday", color: "#222", total: 70, pct: 70 / 120 },
+      { groupId: "g1", name: "Japan", color: "#111", total: 50, pct: 50 / 120 },
+    ]);
+  });
+
+  it("pct denominator excludes ungrouped spending", () => {
+    const expenses = [
+      mkExpense("1", "2026-04-01", 100, "a", "a", "g1"),
+      mkExpense("2", "2026-04-02", 900, "a", "b"), // ungrouped, should not affect pct
+    ];
+    const rows = sumByGroup(expenses, groups);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].pct).toBe(1);
+  });
+
+  it("empty inputs return []", () => {
+    expect(sumByGroup([], groups)).toEqual([]);
+    expect(sumByGroup([], [])).toEqual([]);
   });
 });
 

--- a/src/features/insights/aggregate.ts
+++ b/src/features/insights/aggregate.ts
@@ -1,6 +1,6 @@
 import type { DateRange } from "react-day-picker";
 import { describePeriod } from "@/lib/describePeriod";
-import type { Category, Expense } from "@/types/expense";
+import type { Category, Expense, Group } from "@/types/expense";
 
 export type PeriodKey =
   | "last30"
@@ -179,6 +179,47 @@ export const sumByCategory = (
       categoryId: c.id,
       name: c.name,
       color: c.color,
+      total,
+      pct: grand > 0 ? total / grand : 0,
+    });
+  }
+  rows.sort((a, b) => b.total - a.total);
+  return rows;
+};
+
+export interface GroupTotal {
+  groupId: string;
+  name: string;
+  color: string;
+  total: number;
+  pct: number;
+}
+
+/**
+ * Totals per group, sorted desc by total. Expenses without a groupId are
+ * ignored. `pct` is share of total spending *within grouped expenses* — i.e.
+ * ungrouped spending is excluded from the denominator.
+ */
+export const sumByGroup = (
+  expenses: Expense[],
+  groups: Group[]
+): GroupTotal[] => {
+  const byId = new Map<string, number>();
+  let grand = 0;
+  for (const e of expenses) {
+    if (!e.groupId) continue;
+    byId.set(e.groupId, (byId.get(e.groupId) ?? 0) + e.amount);
+    grand += e.amount;
+  }
+
+  const rows: GroupTotal[] = [];
+  for (const g of groups) {
+    const total = byId.get(g.id) ?? 0;
+    if (total === 0) continue;
+    rows.push({
+      groupId: g.id,
+      name: g.name,
+      color: g.color,
       total,
       pct: grand > 0 ? total / grand : 0,
     });

--- a/src/hooks/useGroups.ts
+++ b/src/hooks/useGroups.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useState } from "react";
+import { subscribeGroups } from "../services/groups";
+import type { Group } from "../types/expense";
+
+export interface UseGroupsState {
+  groups: Group[];
+  byId: Map<string, Group>;
+  loading: boolean;
+  error: Error | null;
+}
+
+export const useGroups = (uid: string | null): UseGroupsState => {
+  const [inner, setInner] = useState<{
+    groups: Group[];
+    loading: boolean;
+    error: Error | null;
+  }>({ groups: [], loading: true, error: null });
+
+  useEffect(() => {
+    if (!uid) {
+      setInner({ groups: [], loading: false, error: null });
+      return;
+    }
+    setInner((s) => ({ ...s, loading: true }));
+    const unsubscribe = subscribeGroups(
+      uid,
+      (groups) => setInner({ groups, loading: false, error: null }),
+      (error) => setInner((s) => ({ ...s, loading: false, error }))
+    );
+    return () => unsubscribe();
+  }, [uid]);
+
+  const byId = useMemo(
+    () => new Map(inner.groups.map((g) => [g.id, g])),
+    [inner.groups]
+  );
+
+  return { ...inner, byId };
+};

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -1,17 +1,8 @@
-import {
-  ColumnDef,
-  RowSelectionState,
-  SortingFn,
-} from "@tanstack/react-table";
+import { RowSelectionState } from "@tanstack/react-table";
 import { endOfMonth, startOfMonth } from "date-fns";
 import {
-  ArrowUpDown,
   Download,
-  MoreHorizontal,
-  Pencil,
   Plus,
-  Repeat,
-  RotateCcw,
   Trash2,
   Upload,
   X,
@@ -19,7 +10,6 @@ import {
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import BulkChangeCategoryDialog from "../../components/BulkChangeCategoryDialog";
-import CategoryBadge from "../../components/CategoryBadge";
 import { DataTable } from "../../components/DataTable";
 import SelectionActionBar from "../../components/SelectionActionBar";
 import ExpenseFilters, {
@@ -42,17 +32,10 @@ import {
   AlertDialogTitle,
 } from "../../components/ui/alert-dialog";
 import { Button } from "../../components/ui/button";
-import { Checkbox } from "../../components/ui/checkbox";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu";
 import { Skeleton } from "../../components/ui/skeleton";
 import { useCategories } from "../../hooks/useCategories";
 import { useExpenses } from "../../hooks/useExpenses";
+import { useGroups } from "../../hooks/useGroups";
 import { addCategory } from "../../services/categories";
 import {
   addExpense,
@@ -66,33 +49,24 @@ import { addRecurring } from "../../services/recurring";
 import type { Expense } from "../../types/expense";
 import { downloadExpenseCsv } from "../../features/export/exportCsv";
 import ImportDialog from "../../features/import/ImportDialog";
+import { buildExpenseColumns } from "./columns";
+import { applyExpenseFilters } from "./filters";
 
 interface ExpensesProps {
   uid: string;
 }
 
-const currency = new Intl.NumberFormat("pt-BR", {
-  style: "currency",
-  currency: "BRL",
-});
-
-const compareByCategoryName =
-  (byId: Map<string, { name: string }>): SortingFn<Expense> =>
-  (a, b) => {
-    const an = byId.get(a.original.categoryId)?.name ?? "";
-    const bn = byId.get(b.original.categoryId)?.name ?? "";
-    return an.localeCompare(bn);
-  };
-
 const Expenses = ({ uid }: ExpensesProps) => {
   const { expenses, loading } = useExpenses(uid);
   const { categories, byId } = useCategories(uid);
+  const { groups, byId: groupsById } = useGroups(uid);
 
   const [filters, setFilters] = useState<ExpenseFiltersState>(() => {
     const now = new Date();
     return {
       search: "",
       categoryIds: [],
+      groupIds: [],
       dateRange: { from: startOfMonth(now), to: endOfMonth(now) },
     };
   });
@@ -106,35 +80,10 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const [importOpen, setImportOpen] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const filtered = useMemo(() => {
-    const search = filters.search.trim().toLowerCase();
-    const fromIso = filters.dateRange?.from
-      ? toIsoDate(filters.dateRange.from)
-      : undefined;
-    const toIso = filters.dateRange?.to
-      ? toIsoDate(filters.dateRange.to)
-      : filters.dateRange?.from
-        ? toIsoDate(filters.dateRange.from)
-        : undefined;
-
-    return expenses.filter((e) => {
-      if (search) {
-        const category = byId.get(e.categoryId)?.name?.toLowerCase() ?? "";
-        if (
-          !e.name.toLowerCase().includes(search) &&
-          !category.includes(search)
-        ) {
-          return false;
-        }
-      }
-      if (filters.categoryIds.length > 0) {
-        if (!filters.categoryIds.includes(e.categoryId)) return false;
-      }
-      if (fromIso && e.date < fromIso) return false;
-      if (toIso && e.date > toIso) return false;
-      return true;
-    });
-  }, [expenses, byId, filters]);
+  const filtered = useMemo(
+    () => applyExpenseFilters(expenses, byId, filters),
+    [expenses, byId, filters]
+  );
 
   const totals = useMemo(() => {
     const nonRefunded = filtered.filter((e) => !e.refunded);
@@ -150,185 +99,21 @@ const Expenses = ({ uid }: ExpensesProps) => {
     [rowSelection]
   );
 
-  const columns = useMemo<ColumnDef<Expense>[]>(
-    () => [
-      {
-        id: "select",
-        header: ({ table }) => (
-          <Checkbox
-            checked={
-              table.getIsAllPageRowsSelected() ||
-              (table.getIsSomePageRowsSelected() && "indeterminate")
-            }
-            onCheckedChange={(value) =>
-              table.toggleAllPageRowsSelected(!!value)
-            }
-            aria-label="Select all"
-          />
-        ),
-        cell: ({ row }) => (
-          <Checkbox
-            checked={row.getIsSelected()}
-            onCheckedChange={(value) => row.toggleSelected(!!value)}
-            aria-label="Select row"
-          />
-        ),
-        enableSorting: false,
-      },
-      {
-        accessorKey: "name",
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Name <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
-          </Button>
-        ),
-        cell: ({ row }) => (
-          <span className="inline-flex items-center gap-2">
-            <span
-              className={
-                row.original.refunded
-                  ? "font-medium line-through text-muted-foreground"
-                  : "font-medium"
-              }
-            >
-              {row.original.name}
-            </span>
-            {row.original.recurringId && (
-              <span
-                className="inline-flex items-center text-muted-foreground"
-                title="Recurring"
-                aria-label="Recurring"
-              >
-                <Repeat className="h-3.5 w-3.5" />
-              </span>
-            )}
-            {row.original.refunded && (
-              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                Refunded
-              </span>
-            )}
-          </span>
-        ),
-      },
-      {
-        accessorKey: "amount",
-        header: ({ column }) => (
-          <div className="flex justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="-mr-3"
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            >
-              Amount <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
-            </Button>
-          </div>
-        ),
-        cell: ({ row }) => (
-          <div
-            className={
-              row.original.refunded
-                ? "text-right font-medium tabular-nums line-through text-muted-foreground"
-                : "text-right font-medium tabular-nums"
-            }
-          >
-            {currency.format(row.original.amount)}
-          </div>
-        ),
-      },
-      {
-        id: "category",
-        header: "Category",
-        cell: ({ row }) => (
-          <CategoryBadge category={byId.get(row.original.categoryId)} />
-        ),
-        sortingFn: compareByCategoryName(byId),
-        enableSorting: true,
-      },
-      {
-        accessorKey: "date",
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            Date <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
-          </Button>
-        ),
-        cell: ({ row }) => (
-          <span className="text-muted-foreground">
-            {new Date(row.original.date).toLocaleDateString()}
-          </span>
-        ),
-      },
-      {
-        id: "actions",
-        header: () => <span className="sr-only">Actions</span>,
-        cell: ({ row }) => (
-          <div className="flex justify-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" aria-label="Row actions">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onSelect={() => {
-                    setEditing(row.original);
-                    setFormOpen(true);
-                  }}
-                >
-                  <Pencil className="h-4 w-4" /> Edit
-                </DropdownMenuItem>
-                {!row.original.recurringId && (
-                  <DropdownMenuItem
-                    onSelect={() => setPromoting(row.original)}
-                  >
-                    <Repeat className="h-4 w-4" /> Make recurring
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem
-                  onSelect={async () => {
-                    const next = !row.original.refunded;
-                    await updateExpense(uid, row.original.id, {
-                      refunded: next,
-                    });
-                    toast.success(
-                      next
-                        ? `Marked "${row.original.name}" as refunded`
-                        : `Unmarked "${row.original.name}"`
-                    );
-                  }}
-                >
-                  <RotateCcw className="h-4 w-4" />{" "}
-                  {row.original.refunded
-                    ? "Unmark refunded"
-                    : "Mark as refunded"}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  className="text-destructive"
-                  onSelect={() => setDeleting(row.original)}
-                >
-                  <Trash2 className="h-4 w-4" /> Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ),
-      },
-    ],
-    [byId, uid]
+  const columns = useMemo(
+    () =>
+      buildExpenseColumns({
+        uid,
+        byId,
+        groupsById,
+        onEdit: (e) => {
+          setEditing(e);
+          setFormOpen(true);
+        },
+        onDelete: (e) => setDeleting(e),
+        onPromote: (e) => setPromoting(e),
+        includeGroup: groups.length > 0,
+      }),
+    [uid, byId, groupsById, groups.length]
   );
 
   const handleCreate = async (values: ExpenseFormResult) => {
@@ -346,6 +131,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
         amount: values.amount,
         date: values.date,
         categoryId: values.categoryId,
+        groupId: values.groupId,
         recurringId,
       });
       toast.success(`Added recurring "${values.name}"`);
@@ -356,17 +142,21 @@ const Expenses = ({ uid }: ExpensesProps) => {
       amount: values.amount,
       date: values.date,
       categoryId: values.categoryId,
+      groupId: values.groupId,
     });
     toast.success(`Added "${values.name}"`);
   };
 
   const handleUpdate = async (values: ExpenseFormResult) => {
     if (!editing) return;
+    const nextGroupId =
+      values.groupId ?? (editing.groupId ? null : undefined);
     await updateExpense(uid, editing.id, {
       name: values.name,
       amount: values.amount,
       date: values.date,
       categoryId: values.categoryId,
+      groupId: nextGroupId,
     });
     toast.success(`Updated "${values.name}"`);
     setEditing(null);
@@ -453,6 +243,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const renderToolbar = () => (
     <ExpenseFilters
       categories={categories}
+      groups={groups}
       value={filters}
       onChange={setFilters}
     />
@@ -544,6 +335,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
         title={editing ? "Edit expense" : "New expense"}
         submitLabel={editing ? "Save" : "Add"}
         categories={categories}
+        groups={groups}
         allowRecurring={!editing}
         initialValue={
           editing
@@ -552,6 +344,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
                 amount: editing.amount,
                 date: editing.date,
                 categoryId: editing.categoryId,
+                groupId: editing.groupId,
               }
             : undefined
         }
@@ -665,13 +458,6 @@ const Expenses = ({ uid }: ExpensesProps) => {
       </SelectionActionBar>
     </div>
   );
-};
-
-const toIsoDate = (d: Date) => {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
 };
 
 export default Expenses;

--- a/src/pages/Expenses/columns.tsx
+++ b/src/pages/Expenses/columns.tsx
@@ -1,0 +1,257 @@
+import { ColumnDef, SortingFn } from "@tanstack/react-table";
+import {
+  ArrowUpDown,
+  MoreHorizontal,
+  Pencil,
+  Repeat,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import CategoryBadge from "../../components/CategoryBadge";
+import { Button } from "../../components/ui/button";
+import { Checkbox } from "../../components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
+import { updateExpense } from "../../services/expenses";
+import type { Category, Expense, Group } from "../../types/expense";
+
+const currency = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+const compareByCategoryName =
+  (byId: Map<string, { name: string }>): SortingFn<Expense> =>
+  (a, b) => {
+    const an = byId.get(a.original.categoryId)?.name ?? "";
+    const bn = byId.get(b.original.categoryId)?.name ?? "";
+    return an.localeCompare(bn);
+  };
+
+export interface BuildExpenseColumnsOptions {
+  uid: string;
+  byId: Map<string, Category>;
+  groupsById?: Map<string, Group>;
+  onEdit: (expense: Expense) => void;
+  onDelete: (expense: Expense) => void;
+  onPromote?: (expense: Expense) => void;
+  includeSelect?: boolean;
+  includeGroup?: boolean;
+}
+
+export const buildExpenseColumns = ({
+  uid,
+  byId,
+  groupsById,
+  onEdit,
+  onDelete,
+  onPromote,
+  includeSelect = true,
+  includeGroup = false,
+}: BuildExpenseColumnsOptions): ColumnDef<Expense>[] => {
+  const columns: ColumnDef<Expense>[] = [];
+
+  if (includeSelect) {
+    columns.push({
+      id: "select",
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && "indeterminate")
+          }
+          onCheckedChange={(value) =>
+            table.toggleAllPageRowsSelected(!!value)
+          }
+          aria-label="Select all"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+        />
+      ),
+      enableSorting: false,
+    });
+  }
+
+  columns.push({
+    accessorKey: "name",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="-ml-3"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Name <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <span className="inline-flex items-center gap-2">
+        <span
+          className={
+            row.original.refunded
+              ? "font-medium line-through text-muted-foreground"
+              : "font-medium"
+          }
+        >
+          {row.original.name}
+        </span>
+        {row.original.recurringId && (
+          <span
+            className="inline-flex items-center text-muted-foreground"
+            title="Recurring"
+            aria-label="Recurring"
+          >
+            <Repeat className="h-3.5 w-3.5" />
+          </span>
+        )}
+        {row.original.refunded && (
+          <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            Refunded
+          </span>
+        )}
+      </span>
+    ),
+  });
+
+  columns.push({
+    accessorKey: "amount",
+    header: ({ column }) => (
+      <div className="flex justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-mr-3"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          Amount <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
+        </Button>
+      </div>
+    ),
+    cell: ({ row }) => (
+      <div
+        className={
+          row.original.refunded
+            ? "text-right font-medium tabular-nums line-through text-muted-foreground"
+            : "text-right font-medium tabular-nums"
+        }
+      >
+        {currency.format(row.original.amount)}
+      </div>
+    ),
+  });
+
+  columns.push({
+    id: "category",
+    header: "Category",
+    cell: ({ row }) => (
+      <CategoryBadge category={byId.get(row.original.categoryId)} />
+    ),
+    sortingFn: compareByCategoryName(byId),
+    enableSorting: true,
+  });
+
+  if (includeGroup && groupsById) {
+    columns.push({
+      id: "group",
+      header: "Group",
+      cell: ({ row }) => {
+        const g = row.original.groupId
+          ? groupsById.get(row.original.groupId)
+          : undefined;
+        return g ? (
+          <span className="inline-flex items-center gap-1.5 text-sm">
+            <span
+              className="h-2 w-2 rounded-[2px]"
+              style={{ backgroundColor: g.color }}
+              aria-hidden
+            />
+            <span className="truncate">{g.name}</span>
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        );
+      },
+    });
+  }
+
+  columns.push({
+    accessorKey: "date",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="-ml-3"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Date <ArrowUpDown className="ml-1 h-3.5 w-3.5" />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {new Date(row.original.date).toLocaleDateString()}
+      </span>
+    ),
+  });
+
+  columns.push({
+    id: "actions",
+    header: () => <span className="sr-only">Actions</span>,
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Row actions">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => onEdit(row.original)}>
+              <Pencil className="h-4 w-4" /> Edit
+            </DropdownMenuItem>
+            {onPromote && !row.original.recurringId && (
+              <DropdownMenuItem onSelect={() => onPromote(row.original)}>
+                <Repeat className="h-4 w-4" /> Make recurring
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              onSelect={async () => {
+                const next = !row.original.refunded;
+                await updateExpense(uid, row.original.id, { refunded: next });
+                toast.success(
+                  next
+                    ? `Marked "${row.original.name}" as refunded`
+                    : `Unmarked "${row.original.name}"`
+                );
+              }}
+            >
+              <RotateCcw className="h-4 w-4" />{" "}
+              {row.original.refunded
+                ? "Unmark refunded"
+                : "Mark as refunded"}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive"
+              onSelect={() => onDelete(row.original)}
+            >
+              <Trash2 className="h-4 w-4" /> Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    ),
+  });
+
+  return columns;
+};

--- a/src/pages/Expenses/filters.test.ts
+++ b/src/pages/Expenses/filters.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { Category, Expense } from "@/types/expense";
+import { NO_GROUP_FILTER } from "@/components/ExpenseFilters";
+import { applyExpenseFilters } from "./filters";
+
+const ts = { seconds: 0, nanoseconds: 0 } as unknown as Expense["createdAt"];
+
+const mkExpense = (
+  id: string,
+  date: string,
+  amount: number,
+  categoryId: string,
+  name: string,
+  groupId?: string
+): Expense => ({
+  id,
+  name,
+  amount,
+  date,
+  categoryId,
+  groupId,
+  createdAt: ts,
+  updatedAt: ts,
+});
+
+const cat = (id: string, name: string): Category => ({
+  id,
+  name,
+  color: "#000000",
+  icon: "Package",
+  order: 0,
+  createdAt: ts,
+});
+
+const byId = new Map(
+  [cat("cat1", "Food"), cat("cat2", "Travel")].map((c) => [c.id, c])
+);
+
+const expenses: Expense[] = [
+  mkExpense("1", "2026-04-01", 10, "cat1", "Pizza", "g1"),
+  mkExpense("2", "2026-04-02", 20, "cat2", "Shinkansen", "g1"),
+  mkExpense("3", "2026-04-03", 30, "cat1", "Sushi", "g2"),
+  mkExpense("4", "2026-04-04", 40, "cat2", "Taxi"),
+];
+
+const baseFilters = {
+  search: "",
+  categoryIds: [] as string[],
+  groupIds: [] as string[],
+  dateRange: undefined,
+};
+
+describe("applyExpenseFilters", () => {
+  it("returns all expenses when no filters are set", () => {
+    expect(applyExpenseFilters(expenses, byId, baseFilters)).toEqual(expenses);
+  });
+
+  it("groupIds: ['g1'] keeps only g1 and excludes ungrouped + other groups", () => {
+    const result = applyExpenseFilters(expenses, byId, {
+      ...baseFilters,
+      groupIds: ["g1"],
+    });
+    expect(result.map((e) => e.id)).toEqual(["1", "2"]);
+  });
+
+  it("groupIds: ['__none__'] returns only expenses with no groupId", () => {
+    const result = applyExpenseFilters(expenses, byId, {
+      ...baseFilters,
+      groupIds: [NO_GROUP_FILTER],
+    });
+    expect(result.map((e) => e.id)).toEqual(["4"]);
+  });
+
+  it("groupIds: ['g1', '__none__'] returns the union", () => {
+    const result = applyExpenseFilters(expenses, byId, {
+      ...baseFilters,
+      groupIds: ["g1", NO_GROUP_FILTER],
+    });
+    expect(result.map((e) => e.id).sort()).toEqual(["1", "2", "4"]);
+  });
+
+  it("combines search + category + group with AND", () => {
+    const result = applyExpenseFilters(expenses, byId, {
+      ...baseFilters,
+      search: "sushi",
+      categoryIds: ["cat1"],
+      groupIds: ["g2"],
+    });
+    expect(result.map((e) => e.id)).toEqual(["3"]);
+  });
+
+  it("categoryIds alone still works", () => {
+    const result = applyExpenseFilters(expenses, byId, {
+      ...baseFilters,
+      categoryIds: ["cat2"],
+    });
+    expect(result.map((e) => e.id)).toEqual(["2", "4"]);
+  });
+});

--- a/src/pages/Expenses/filters.ts
+++ b/src/pages/Expenses/filters.ts
@@ -1,0 +1,59 @@
+import type { DateRange } from "react-day-picker";
+import { NO_GROUP_FILTER } from "../../components/ExpenseFilters";
+import type { Category, Expense } from "../../types/expense";
+
+export interface ExpenseFilterInput {
+  search: string;
+  categoryIds: string[];
+  groupIds: string[];
+  dateRange: DateRange | undefined;
+}
+
+const toIsoDate = (d: Date) => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+export const applyExpenseFilters = (
+  expenses: Expense[],
+  byId: Map<string, Pick<Category, "name">>,
+  filters: ExpenseFilterInput
+): Expense[] => {
+  const search = filters.search.trim().toLowerCase();
+  const fromIso = filters.dateRange?.from
+    ? toIsoDate(filters.dateRange.from)
+    : undefined;
+  const toIso = filters.dateRange?.to
+    ? toIsoDate(filters.dateRange.to)
+    : filters.dateRange?.from
+      ? toIsoDate(filters.dateRange.from)
+      : undefined;
+
+  return expenses.filter((e) => {
+    if (search) {
+      const category = byId.get(e.categoryId)?.name?.toLowerCase() ?? "";
+      if (
+        !e.name.toLowerCase().includes(search) &&
+        !category.includes(search)
+      ) {
+        return false;
+      }
+    }
+    if (filters.categoryIds.length > 0) {
+      if (!filters.categoryIds.includes(e.categoryId)) return false;
+    }
+    if (filters.groupIds.length > 0) {
+      const wantsNone = filters.groupIds.includes(NO_GROUP_FILTER);
+      const realIds = filters.groupIds.filter((x) => x !== NO_GROUP_FILTER);
+      const eg = e.groupId;
+      const matches =
+        (wantsNone && !eg) || (!!eg && realIds.includes(eg));
+      if (!matches) return false;
+    }
+    if (fromIso && e.date < fromIso) return false;
+    if (toIso && e.date > toIso) return false;
+    return true;
+  });
+};

--- a/src/pages/GroupDetail/GroupDetail.tsx
+++ b/src/pages/GroupDetail/GroupDetail.tsx
@@ -1,0 +1,328 @@
+import { ArrowLeft, Hash, Pencil, Trash2, Wallet } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { CategoryIcon } from "../../components/CategoryIcon";
+import { DataTable } from "../../components/DataTable";
+import DeleteGroupDialog, {
+  type DeleteGroupAction,
+} from "../../components/DeleteGroupDialog";
+import ExpenseForm, {
+  ExpenseFormResult,
+} from "../../components/ExpenseForm";
+import GroupForm, {
+  type GroupFormValues,
+} from "../../components/GroupForm";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../components/ui/alert-dialog";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Skeleton } from "../../components/ui/skeleton";
+import CategoryBreakdownChart from "../../features/insights/CategoryBreakdownChart";
+import KpiCard from "../../features/insights/KpiCard";
+import { formatBRL } from "../../features/insights/formatBRL";
+import { sumByCategory } from "../../features/insights/aggregate";
+import { useCategories } from "../../hooks/useCategories";
+import { useExpenses } from "../../hooks/useExpenses";
+import { useGroups } from "../../hooks/useGroups";
+import { contrastingText } from "../../lib/categoryPalette";
+import { deleteExpense, updateExpense } from "../../services/expenses";
+import { bulkUpdateGroup } from "../../services/expenses";
+import { deleteGroup, updateGroup } from "../../services/groups";
+import type { Expense } from "../../types/expense";
+import { buildExpenseColumns } from "../Expenses/columns";
+
+interface GroupDetailProps {
+  uid: string;
+}
+
+const GroupDetail = ({ uid }: GroupDetailProps) => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { groups, byId: groupsById, loading: loadingGroups } = useGroups(uid);
+  const { categories, byId } = useCategories(uid);
+  const { expenses, loading: loadingExpenses } = useExpenses(uid);
+
+  const group = id ? groupsById.get(id) : undefined;
+
+  const groupExpenses = useMemo(
+    () => expenses.filter((e) => e.groupId === id),
+    [expenses, id]
+  );
+
+  const totalSpent = useMemo(
+    () =>
+      groupExpenses
+        .filter((e) => !e.refunded)
+        .reduce((acc, e) => acc + e.amount, 0),
+    [groupExpenses]
+  );
+
+  const byCategory = useMemo(
+    () =>
+      sumByCategory(
+        groupExpenses.filter((e) => !e.refunded),
+        categories
+      ),
+    [groupExpenses, categories]
+  );
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [deletingExpense, setDeletingExpense] = useState<Expense | null>(null);
+
+  const columns = useMemo(
+    () =>
+      buildExpenseColumns({
+        uid,
+        byId,
+        onEdit: (e) => setEditingExpense(e),
+        onDelete: (e) => setDeletingExpense(e),
+        includeSelect: false,
+      }),
+    [uid, byId]
+  );
+
+  const handleEditGroup = async (values: GroupFormValues) => {
+    if (!group) return;
+    await updateGroup(uid, group.id, values);
+    toast.success(`Updated group "${values.name}"`);
+  };
+
+  const handleDeleteGroup = async (args: DeleteGroupAction) => {
+    if (!group) return;
+    const ids = groupExpenses.map((e) => e.id);
+    if (ids.length > 0) {
+      await bulkUpdateGroup(
+        uid,
+        ids,
+        args.action === "reassign" ? args.reassignToId : null
+      );
+    }
+    await deleteGroup(uid, group.id);
+    toast.success(`Deleted group "${group.name}"`);
+    setDeleting(false);
+    navigate("/groups");
+  };
+
+  const handleUpdateExpense = async (values: ExpenseFormResult) => {
+    if (!editingExpense) return;
+    const nextGroupId =
+      values.groupId ?? (editingExpense.groupId ? null : undefined);
+    await updateExpense(uid, editingExpense.id, {
+      name: values.name,
+      amount: values.amount,
+      date: values.date,
+      categoryId: values.categoryId,
+      groupId: nextGroupId,
+    });
+    toast.success(`Updated "${values.name}"`);
+    setEditingExpense(null);
+  };
+
+  const handleDeleteExpense = async () => {
+    if (!deletingExpense) return;
+    await deleteExpense(uid, deletingExpense.id);
+    toast.success(`Deleted "${deletingExpense.name}"`);
+    setDeletingExpense(null);
+  };
+
+  const loading = loadingGroups || loadingExpenses;
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Skeleton className="h-24" />
+          <Skeleton className="h-24" />
+        </div>
+        <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div className="space-y-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/groups">
+            <ArrowLeft className="h-4 w-4" /> Back to groups
+          </Link>
+        </Button>
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-muted-foreground">Group not found.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0">
+          <Button asChild variant="ghost" size="icon" aria-label="Back">
+            <Link to="/groups">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <div
+            className="h-10 w-10 shrink-0 rounded-lg flex items-center justify-center"
+            style={{
+              backgroundColor: group.color,
+              color: contrastingText(group.color),
+            }}
+          >
+            <CategoryIcon name={group.icon} className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold tracking-tight truncate">
+              {group.name}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Expenses tagged to this group.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => setEditOpen(true)}>
+            <Pencil className="h-4 w-4" />
+            <span className="ml-2">Edit</span>
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => setDeleting(true)}
+            className="text-destructive hover:text-destructive hover:bg-destructive/10"
+          >
+            <Trash2 className="h-4 w-4" />
+            <span className="ml-2">Delete</span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <KpiCard
+          label="Total spent"
+          value={formatBRL(totalSpent)}
+          icon={Wallet}
+          index={0}
+        />
+        <KpiCard
+          label="Expenses"
+          value={String(groupExpenses.length)}
+          icon={Hash}
+          index={1}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>By category</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {byCategory.length > 0 ? (
+            <CategoryBreakdownChart data={byCategory} />
+          ) : (
+            <p className="text-sm text-muted-foreground py-8 text-center">
+              No expenses in this group yet.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Expenses</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DataTable
+            columns={columns}
+            data={groupExpenses}
+            emptyMessage="No expenses in this group yet."
+            getRowId={(row) => row.id}
+          />
+        </CardContent>
+      </Card>
+
+      <GroupForm
+        open={editOpen}
+        title="Edit group"
+        submitLabel="Save"
+        initialValue={{
+          name: group.name,
+          color: group.color,
+          icon: group.icon,
+        }}
+        onOpenChange={setEditOpen}
+        onSubmit={handleEditGroup}
+      />
+
+      <DeleteGroupDialog
+        open={deleting}
+        group={group}
+        otherGroups={groups.filter((g) => g.id !== group.id)}
+        expenseCount={groupExpenses.length}
+        onOpenChange={setDeleting}
+        onConfirm={handleDeleteGroup}
+      />
+
+      <ExpenseForm
+        open={!!editingExpense}
+        title="Edit expense"
+        submitLabel="Save"
+        categories={categories}
+        groups={groups}
+        allowRecurring={false}
+        initialValue={
+          editingExpense
+            ? {
+                name: editingExpense.name,
+                amount: editingExpense.amount,
+                date: editingExpense.date,
+                categoryId: editingExpense.categoryId,
+                groupId: editingExpense.groupId,
+              }
+            : undefined
+        }
+        onOpenChange={(open) => !open && setEditingExpense(null)}
+        onSubmit={handleUpdateExpense}
+      />
+
+      <AlertDialog
+        open={!!deletingExpense}
+        onOpenChange={(open) => !open && setDeletingExpense(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete expense?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove &quot;{deletingExpense?.name}&quot;.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeleteExpense}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+};
+
+export default GroupDetail;

--- a/src/pages/GroupDetail/index.ts
+++ b/src/pages/GroupDetail/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GroupDetail";

--- a/src/pages/Groups/Groups.tsx
+++ b/src/pages/Groups/Groups.tsx
@@ -1,0 +1,218 @@
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { CategoryIcon } from "../../components/CategoryIcon";
+import DeleteGroupDialog, {
+  type DeleteGroupAction,
+} from "../../components/DeleteGroupDialog";
+import GroupForm, {
+  type GroupFormValues,
+} from "../../components/GroupForm";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent } from "../../components/ui/card";
+import { Skeleton } from "../../components/ui/skeleton";
+import { useExpenses } from "../../hooks/useExpenses";
+import { useGroups } from "../../hooks/useGroups";
+import { contrastingText } from "../../lib/categoryPalette";
+import { addGroup, deleteGroup, updateGroup } from "../../services/groups";
+import { bulkUpdateGroup } from "../../services/expenses";
+import type { Group } from "../../types/expense";
+
+interface GroupsProps {
+  uid: string;
+}
+
+const Groups = ({ uid }: GroupsProps) => {
+  const { groups, loading } = useGroups(uid);
+  const { expenses } = useExpenses(uid);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Group | null>(null);
+  const [deleting, setDeleting] = useState<Group | null>(null);
+
+  const expenseCountByGroup = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of expenses) {
+      if (!e.groupId) continue;
+      map.set(e.groupId, (map.get(e.groupId) ?? 0) + 1);
+    }
+    return map;
+  }, [expenses]);
+
+  const handleCreate = async (values: GroupFormValues) => {
+    await addGroup(uid, { ...values, order: groups.length });
+    toast.success(`Created group "${values.name}"`);
+  };
+
+  const handleUpdate = async (values: GroupFormValues) => {
+    if (!editing) return;
+    await updateGroup(uid, editing.id, values);
+    toast.success(`Updated group "${values.name}"`);
+  };
+
+  const handleDelete = async (args: DeleteGroupAction) => {
+    if (!deleting) return;
+    const ids = expenses
+      .filter((e) => e.groupId === deleting.id)
+      .map((e) => e.id);
+    if (ids.length > 0) {
+      await bulkUpdateGroup(
+        uid,
+        ids,
+        args.action === "reassign" ? args.reassignToId : null
+      );
+    }
+    await deleteGroup(uid, deleting.id);
+    toast.success(`Deleted group "${deleting.name}"`);
+    setDeleting(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Groups</h1>
+          <p className="text-sm text-muted-foreground">
+            Bundle expenses by occasion — a trip, an event, or any shared
+            purpose.
+          </p>
+        </div>
+        <Button
+          onClick={() => {
+            setEditing(null);
+            setFormOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4" />
+          New group
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      ) : groups.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center space-y-3">
+            <p className="text-muted-foreground">No groups yet.</p>
+            <Button
+              onClick={() => {
+                setEditing(null);
+                setFormOpen(true);
+              }}
+            >
+              <Plus className="h-4 w-4" /> Create your first group
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {groups.map((group, i) => {
+            const count = expenseCountByGroup.get(group.id) ?? 0;
+            return (
+              <Card
+                key={group.id}
+                className="transition-all hover:border-primary/40 hover:shadow-sm animate-in fade-in-0 slide-in-from-bottom-2 duration-300 fill-mode-both"
+                style={{ animationDelay: `${i * 40}ms` }}
+              >
+                <CardContent className="p-0">
+                  <div className="flex items-center gap-4 p-4">
+                    <Link
+                      to={`/groups/${group.id}`}
+                      className="flex flex-1 items-center gap-4 min-w-0"
+                      aria-label={`Open ${group.name}`}
+                    >
+                      <div
+                        className="h-12 w-12 shrink-0 rounded-lg flex items-center justify-center"
+                        style={{
+                          backgroundColor: group.color,
+                          color: contrastingText(group.color),
+                        }}
+                      >
+                        <CategoryIcon
+                          name={group.icon}
+                          className="h-5 w-5"
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">
+                          {group.name}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {count === 0
+                            ? "No expenses"
+                            : `${count} expense${count === 1 ? "" : "s"}`}
+                        </div>
+                      </div>
+                    </Link>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setEditing(group);
+                          setFormOpen(true);
+                        }}
+                        aria-label={`Edit ${group.name}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setDeleting(group);
+                        }}
+                        aria-label={`Delete ${group.name}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <GroupForm
+        open={formOpen}
+        title={editing ? "Edit group" : "New group"}
+        submitLabel={editing ? "Save" : "Create"}
+        initialValue={
+          editing
+            ? {
+                name: editing.name,
+                color: editing.color,
+                icon: editing.icon,
+              }
+            : undefined
+        }
+        onOpenChange={setFormOpen}
+        onSubmit={editing ? handleUpdate : handleCreate}
+      />
+
+      <DeleteGroupDialog
+        open={!!deleting}
+        group={deleting}
+        otherGroups={groups.filter((g) => g.id !== deleting?.id)}
+        expenseCount={
+          deleting ? expenseCountByGroup.get(deleting.id) ?? 0 : 0
+        }
+        onOpenChange={(open) => !open && setDeleting(null)}
+        onConfirm={handleDelete}
+      />
+    </div>
+  );
+};
+
+export default Groups;

--- a/src/pages/Groups/index.ts
+++ b/src/pages/Groups/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Groups";

--- a/src/pages/Insights/Insights.tsx
+++ b/src/pages/Insights/Insights.tsx
@@ -27,18 +27,21 @@ import { Skeleton } from "@/components/ui/skeleton";
 import MonthSwitcher from "@/components/MonthSwitcher";
 import { useCategories } from "@/hooks/useCategories";
 import { useExpenses } from "@/hooks/useExpenses";
+import { useGroups } from "@/hooks/useGroups";
 import { describePeriod } from "@/lib/describePeriod";
 import {
   computeKpis,
   filterByPeriod,
   periodFromDateRange,
   sumByCategory,
+  sumByGroup,
   sumByMonth,
   sumByMonthAndCategory,
   topExpenses,
 } from "@/features/insights/aggregate";
 import CategoryBreakdownChart from "@/features/insights/CategoryBreakdownChart";
 import CategoryTrendChart from "@/features/insights/CategoryTrendChart";
+import GroupBreakdownChart from "@/features/insights/GroupBreakdownChart";
 import KpiCard from "@/features/insights/KpiCard";
 import MonthlyTrendChart from "@/features/insights/MonthlyTrendChart";
 import TopExpensesList from "@/features/insights/TopExpensesList";
@@ -51,7 +54,8 @@ interface InsightsProps {
 const Insights = ({ uid }: InsightsProps) => {
   const { expenses: rawExpenses, loading: loadingExpenses } = useExpenses(uid);
   const { categories, byId, loading: loadingCategories } = useCategories(uid);
-  const loading = loadingExpenses || loadingCategories;
+  const { groups, loading: loadingGroups } = useGroups(uid);
+  const loading = loadingExpenses || loadingCategories || loadingGroups;
 
   const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
     const now = new Date();
@@ -83,6 +87,10 @@ const Insights = ({ uid }: InsightsProps) => {
   const byCategory = useMemo(
     () => sumByCategory(periodExpenses, categories),
     [periodExpenses, categories]
+  );
+  const byGroup = useMemo(
+    () => sumByGroup(periodExpenses, groups),
+    [periodExpenses, groups]
   );
   const byMonthCategory = useMemo(
     () => sumByMonthAndCategory(periodExpenses, categories, period),
@@ -253,6 +261,23 @@ const Insights = ({ uid }: InsightsProps) => {
           </CardContent>
         </Card>
       </div>
+
+      {groups.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>By group</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {byGroup.length > 0 ? (
+              <GroupBreakdownChart data={byGroup} />
+            ) : (
+              <p className="text-sm text-muted-foreground py-8 text-center">
+                No expenses are assigned to a group in this period.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader>

--- a/src/services/expenses.test.ts
+++ b/src/services/expenses.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+const DELETE_SENTINEL = Symbol("deleteField()");
+
+vi.mock("firebase/firestore", () => ({
+  addDoc: vi.fn(),
+  collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  deleteField: () => DELETE_SENTINEL,
+  doc: vi.fn(),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn(),
+  query: vi.fn(),
+  serverTimestamp: vi.fn(() => "__now__"),
+  updateDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock("./firebase", () => ({
+  db: {},
+}));
+
+import { normalizePatch } from "./expenses";
+
+describe("normalizePatch", () => {
+  it("passes concrete values through", () => {
+    const result = normalizePatch({ groupId: "g1", name: "x" });
+    expect(result).toEqual({ groupId: "g1", name: "x" });
+  });
+
+  it("translates null to deleteField() sentinel", () => {
+    const result = normalizePatch({ groupId: null });
+    expect(result.groupId).toBe(DELETE_SENTINEL);
+  });
+
+  it("omits undefined keys entirely", () => {
+    const result = normalizePatch({ groupId: undefined, name: "x" });
+    expect(result).toEqual({ name: "x" });
+    expect("groupId" in result).toBe(false);
+  });
+
+  it("handles a mix of concrete, null, and undefined", () => {
+    const result = normalizePatch({
+      name: "x",
+      categoryId: undefined,
+      groupId: null,
+      amount: 42,
+    });
+    expect(result).toEqual({
+      name: "x",
+      groupId: DELETE_SENTINEL,
+      amount: 42,
+    });
+  });
+});

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -2,6 +2,7 @@ import {
   addDoc,
   collection,
   deleteDoc,
+  deleteField,
   doc,
   getDocs,
   onSnapshot,
@@ -26,6 +27,7 @@ const mapDoc = (id: string, data: Record<string, unknown>): Expense => ({
   amount: data.amount as number,
   date: data.date as string,
   categoryId: data.categoryId as string,
+  groupId: (data.groupId as string | undefined) ?? undefined,
   recurringId: (data.recurringId as string | undefined) ?? undefined,
   refunded: (data.refunded as boolean | undefined) ?? false,
   createdAt: data.createdAt as Expense["createdAt"],
@@ -57,6 +59,23 @@ const stripUndefined = <T extends Record<string, unknown>>(obj: T): T => {
   return out as T;
 };
 
+// Patch normalizer: `null` → deleteField() sentinel, `undefined` → omitted.
+// Required so update callers can *clear* optional fields like groupId.
+export const normalizePatch = (
+  obj: Record<string, unknown>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === null) out[k] = deleteField();
+    else if (v !== undefined) out[k] = v;
+  }
+  return out;
+};
+
+export type ExpensePatch = Omit<Partial<ExpenseInput>, "groupId"> & {
+  groupId?: string | null;
+};
+
 export const addExpense = async (
   uid: string,
   input: ExpenseInput
@@ -75,15 +94,13 @@ export const addExpense = async (
 export const updateExpense = async (
   uid: string,
   id: string,
-  patch: Partial<ExpenseInput>
+  patch: ExpensePatch
 ): Promise<void> => {
-  await updateDoc(
-    doc(expensesCol(uid), id),
-    stripUndefined({
-      ...patch,
-      updatedAt: serverTimestamp(),
-    })
-  );
+  const normalized = normalizePatch({
+    ...patch,
+    updatedAt: serverTimestamp(),
+  }) as Record<string, never>;
+  await updateDoc(doc(expensesCol(uid), id), normalized);
 };
 
 export const deleteExpense = async (uid: string, id: string): Promise<void> => {
@@ -117,6 +134,24 @@ export const bulkUpdateCategory = async (
     for (const id of group) {
       batch.update(doc(expensesCol(uid), id), {
         categoryId,
+        updatedAt: serverTimestamp(),
+      });
+    }
+    await batch.commit();
+  }
+};
+
+export const bulkUpdateGroup = async (
+  uid: string,
+  ids: string[],
+  groupId: string | null
+): Promise<void> => {
+  const value = groupId === null ? deleteField() : groupId;
+  for (const group of chunk(ids, 450)) {
+    const batch = writeBatch(db);
+    for (const id of group) {
+      batch.update(doc(expensesCol(uid), id), {
+        groupId: value,
         updatedAt: serverTimestamp(),
       });
     }

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,4 +1,8 @@
 import { initializeApp } from "firebase/app";
+import {
+  initializeAppCheck,
+  ReCaptchaEnterpriseProvider,
+} from "firebase/app-check";
 import { getAI, getGenerativeModel, GoogleAIBackend } from "firebase/ai";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
@@ -13,6 +17,25 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
+
+if (import.meta.env.MODE !== "test") {
+  const siteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+  if (siteKey) {
+    if (import.meta.env.DEV) {
+      (
+        self as unknown as { FIREBASE_APPCHECK_DEBUG_TOKEN?: boolean }
+      ).FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+    }
+    initializeAppCheck(app, {
+      provider: new ReCaptchaEnterpriseProvider(siteKey),
+      isTokenAutoRefreshEnabled: true,
+    });
+  } else {
+    console.warn(
+      "[firebase] VITE_RECAPTCHA_SITE_KEY is missing; App Check disabled. See .env.example."
+    );
+  }
+}
 
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -1,0 +1,80 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  writeBatch,
+} from "firebase/firestore";
+import type { Group, GroupInput } from "../types/expense";
+import { db } from "./firebase";
+
+const groupsCol = (uid: string) => collection(db, "users", uid, "groups");
+
+const groupsQuery = (uid: string) =>
+  query(groupsCol(uid), orderBy("order", "asc"));
+
+const mapDoc = (id: string, data: Record<string, unknown>): Group => ({
+  id,
+  name: data.name as string,
+  color: data.color as string,
+  icon: data.icon as string,
+  order: (data.order as number) ?? 0,
+  createdAt: data.createdAt as Group["createdAt"],
+});
+
+export const listGroups = async (uid: string): Promise<Group[]> => {
+  const snap = await getDocs(groupsQuery(uid));
+  return snap.docs.map((d) => mapDoc(d.id, d.data()));
+};
+
+export const subscribeGroups = (
+  uid: string,
+  onNext: (groups: Group[]) => void,
+  onError?: (error: Error) => void
+) => {
+  return onSnapshot(
+    groupsQuery(uid),
+    (snap) => onNext(snap.docs.map((d) => mapDoc(d.id, d.data()))),
+    onError
+  );
+};
+
+export const addGroup = async (
+  uid: string,
+  input: GroupInput
+): Promise<string> => {
+  const ref = await addDoc(groupsCol(uid), {
+    ...input,
+    createdAt: serverTimestamp(),
+  });
+  return ref.id;
+};
+
+export const updateGroup = async (
+  uid: string,
+  id: string,
+  patch: Partial<GroupInput>
+): Promise<void> => {
+  await updateDoc(doc(groupsCol(uid), id), patch);
+};
+
+export const deleteGroup = async (uid: string, id: string): Promise<void> => {
+  await deleteDoc(doc(groupsCol(uid), id));
+};
+
+export const reorderGroups = async (
+  uid: string,
+  ids: string[]
+): Promise<void> => {
+  const batch = writeBatch(db);
+  ids.forEach((id, index) => {
+    batch.update(doc(groupsCol(uid), id), { order: index });
+  });
+  await batch.commit();
+};

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -6,6 +6,7 @@ export interface Expense {
   amount: number;
   date: string;
   categoryId: string;
+  groupId?: string;
   recurringId?: string;
   refunded?: boolean;
   createdAt: Timestamp;
@@ -24,6 +25,17 @@ export interface Category {
 }
 
 export type CategoryInput = Omit<Category, "id" | "createdAt">;
+
+export interface Group {
+  id: string;
+  name: string;
+  color: string;
+  icon: string;
+  order: number;
+  createdAt: Timestamp;
+}
+
+export type GroupInput = Omit<Group, "id" | "createdAt">;
 
 export type RecurringFrequency = "weekly" | "monthly";
 


### PR DESCRIPTION
## Summary
- Adds optional **Group / Occasion** dimension to expenses (e.g. _Japan Trip_) so users can bundle transport + food + lodging across categories.
- Full CRUD at `/groups`, detail view at `/groups/:id` with total spent, expenses list and per-category breakdown.
- Group select in `ExpenseForm` + group multi-select filter (including "No group") in `ExpenseFilters`.
- New `sumByGroup` aggregation and a "By group" card in Insights.
- Firestore rules extended: optional `groupId` on expenses + new `/users/{uid}/groups` subcollection.

## Notable refactors (same PR)
- `buildExpenseColumns` factory extracted to `src/pages/Expenses/columns.tsx` so both the Expenses page and the new Group Detail page share the same table.
- Expense filter predicate lifted to a pure `applyExpenseFilters` in `src/pages/Expenses/filters.ts` (testable, small cleanup).
- `updateExpense` gains a `normalizePatch` helper (`null` → `deleteField()`) so optional fields like `groupId` can be *cleared* — not just set or ignored.

## Deploy order ⚠️
Rules must be deployed **before** the web bundle — the expenses allowlist now includes `groupId`, and client writes carrying it will be rejected by the old rules.
```
firebase deploy --only firestore:rules   # first
# then ship the web build
```

## Out of scope (intentional)
- Group budgets / date ranges / archived status.
- Linking `Recurring` templates to groups.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` — 62 tests pass (new: `sumByGroup`, `applyExpenseFilters`, `GroupForm`, `normalizePatch`)
- [ ] Manual smoke (`npm run dev`):
  - [ ] Create group "Japan Trip" with color + icon
  - [ ] Edit group, confirm it persists
  - [ ] Create expense with group = Japan Trip
  - [ ] `/expenses` filter by group → only matching expenses
  - [ ] Filter `No group` → excludes grouped expenses
  - [ ] Edit expense → set group to **None** → verify `groupId` field is removed in Firestore console
  - [ ] `/groups/:id` shows correct total, expense row, and category breakdown
  - [ ] `/insights` "By group" card renders a slice for Japan Trip
  - [ ] Delete group with expenses → Unset path clears `groupId`; Reassign path moves them