### PR TITLE
refactor(groups): drop color+icon, unified filter popover

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -101,21 +101,18 @@ service cloud.firestore {
 
         allow create: if isOwner(userId)
           && request.resource.data.keys().hasAll(
-            ['name', 'color', 'icon', 'order', 'createdAt']
+            ['name', 'order', 'createdAt']
           )
           && request.resource.data.keys().hasOnly(
-            ['name', 'color', 'icon', 'order', 'createdAt']
+            ['name', 'order', 'createdAt']
           )
           && isNonEmptyString(request.resource.data.name, 80)
-          && request.resource.data.color is string
-          && request.resource.data.color.matches('^#[0-9a-fA-F]{6}$')
-          && isNonEmptyString(request.resource.data.icon, 64)
           && request.resource.data.order is int
           && request.resource.data.order >= 0;
 
         allow update: if isOwner(userId)
           && request.resource.data.diff(resource.data).affectedKeys()
-              .hasOnly(['name', 'color', 'icon', 'order']);
+              .hasOnly(['name', 'order']);
 
         allow delete: if isOwner(userId);
       }

--- a/src/components/BulkChangeGroupDialog.tsx
+++ b/src/components/BulkChangeGroupDialog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Label } from "./ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import type { Group } from "../types/expense";
+
+const NONE = "__none__";
+
+interface BulkChangeGroupDialogProps {
+  open: boolean;
+  count: number;
+  groups: Group[];
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (groupId: string | null) => Promise<void> | void;
+}
+
+const BulkChangeGroupDialog = ({
+  open,
+  count,
+  groups,
+  onOpenChange,
+  onConfirm,
+}: BulkChangeGroupDialogProps) => {
+  const [value, setValue] = useState<string>(NONE);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) setValue(NONE);
+  }, [open]);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onConfirm(value === NONE ? null : value);
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Change group</DialogTitle>
+          <DialogDescription>
+            Move {count} expense{count === 1 ? "" : "s"} into a group, or clear
+            the group assignment.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label>Group</Label>
+          <Select value={value} onValueChange={setValue}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE}>No group</SelectItem>
+              {groups.map((g) => (
+                <SelectItem key={g.id} value={g.id}>
+                  {g.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleConfirm} disabled={submitting}>
+            Apply
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BulkChangeGroupDialog;

--- a/src/components/ColumnFilterDropdown.tsx
+++ b/src/components/ColumnFilterDropdown.tsx
@@ -1,0 +1,115 @@
+import { Filter } from "lucide-react";
+import { Button } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "./ui/popover";
+import { Separator } from "./ui/separator";
+import { cn } from "../lib/utils";
+
+export interface ColumnFilterOption {
+  value: string;
+  label: string;
+  italic?: boolean;
+}
+
+interface ColumnFilterDropdownProps {
+  label: string;
+  options: ColumnFilterOption[];
+  values: string[];
+  onChange: (values: string[]) => void;
+  emptyMessage?: string;
+}
+
+const ColumnFilterDropdown = ({
+  label,
+  options,
+  values,
+  onChange,
+  emptyMessage = "No options",
+}: ColumnFilterDropdownProps) => {
+  const active = values.length > 0;
+
+  const toggle = (value: string, checked: boolean) => {
+    const next = checked
+      ? [...values, value]
+      : values.filter((v) => v !== value);
+    onChange(next);
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            "-ml-2 h-7 gap-1 font-medium",
+            active && "text-primary"
+          )}
+          aria-label={`Filter by ${label.toLowerCase()}`}
+        >
+          <span>{label}</span>
+          <Filter
+            className={cn("h-3.5 w-3.5", active && "fill-primary")}
+          />
+          {active && (
+            <span className="text-xs tabular-nums">{values.length}</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56 p-0">
+        {options.length === 0 ? (
+          <p className="p-3 text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <div className="max-h-64 overflow-auto p-2 space-y-0.5">
+            {options.map((option) => {
+              const id = `col-filter-${label}-${option.value}`;
+              const checked = values.includes(option.value);
+              return (
+                <label
+                  key={option.value}
+                  htmlFor={id}
+                  className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1.5 py-1.5 hover:bg-muted"
+                >
+                  <Checkbox
+                    id={id}
+                    checked={checked}
+                    onCheckedChange={(c) => toggle(option.value, c === true)}
+                  />
+                  <span
+                    className={cn(
+                      "truncate",
+                      option.italic && "italic text-muted-foreground"
+                    )}
+                  >
+                    {option.label}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        )}
+        {active && (
+          <>
+            <Separator />
+            <div className="p-1.5 flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7"
+                onClick={() => onChange([])}
+              >
+                Clear
+              </Button>
+            </div>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default ColumnFilterDropdown;

--- a/src/components/ColumnFilterDropdown.tsx
+++ b/src/components/ColumnFilterDropdown.tsx
@@ -46,7 +46,7 @@ const ColumnFilterDropdown = ({
           variant="ghost"
           size="sm"
           className={cn(
-            "-ml-2 h-7 gap-1 font-medium",
+            "-ml-2 h-7 gap-2 font-medium",
             active && "text-primary"
           )}
           aria-label={`Filter by ${label.toLowerCase()}`}

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -38,6 +38,7 @@ interface DataTableProps<TData, TValue> {
   onRowSelectionChange?: (next: RowSelectionState) => void;
   getRowId?: (row: TData, index: number) => string;
   renderToolbar?: (table: TanstackTable<TData>) => React.ReactNode;
+  meta?: Record<string, unknown>;
 }
 
 export function DataTable<TData, TValue>({
@@ -48,6 +49,7 @@ export function DataTable<TData, TValue>({
   onRowSelectionChange,
   getRowId,
   renderToolbar,
+  meta,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
@@ -77,6 +79,7 @@ export function DataTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     enableRowSelection: !!onRowSelectionChange,
     getRowId,
+    meta,
   });
 
   const filteredRowCount = table.getFilteredRowModel().rows.length;

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -1,17 +1,12 @@
-import { CalendarIcon, Filter, Search, Users, X } from "lucide-react";
+import { Filter, Search, X } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "./ui/button";
 import { Calendar } from "./ui/calendar";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
+import { Checkbox } from "./ui/checkbox";
 import { Input } from "./ui/input";
+import { Label } from "./ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Separator } from "./ui/separator";
 import MonthSwitcher from "./MonthSwitcher";
 import type { Category, Group } from "../types/expense";
 
@@ -30,6 +25,13 @@ interface ExpenseFiltersProps {
   value: ExpenseFiltersState;
   onChange: (next: ExpenseFiltersState) => void;
 }
+
+const EMPTY: ExpenseFiltersState = {
+  search: "",
+  categoryIds: [],
+  groupIds: [],
+  dateRange: undefined,
+};
 
 const ExpenseFilters = ({
   categories,
@@ -51,16 +53,16 @@ const ExpenseFilters = ({
     onChange({ ...value, groupIds: next });
   };
 
-  const categoryCount = value.categoryIds.length;
-  const groupCount = value.groupIds.length;
-
   const hasGroupsUi = !!groups;
 
-  const hasActive =
-    value.search.length > 0 ||
-    value.categoryIds.length > 0 ||
-    value.groupIds.length > 0 ||
-    !!value.dateRange;
+  const activeCount =
+    value.categoryIds.length +
+    value.groupIds.length +
+    (value.dateRange ? 1 : 0);
+
+  const hasActive = activeCount > 0 || value.search.length > 0;
+
+  const reset = () => onChange(EMPTY);
 
   return (
     <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
@@ -74,132 +76,147 @@ const ExpenseFilters = ({
         />
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
+      <div className="flex items-center gap-2 flex-wrap">
+        <Popover>
+          <PopoverTrigger asChild>
             <Button
               variant="outline"
-              size={categoryCount === 0 ? "icon" : "default"}
-              aria-label="Filter by category"
-              title="Filter by category"
+              size={activeCount === 0 ? "icon" : "default"}
+              aria-label="Filters"
+              title="Filters"
             >
               <Filter className="h-4 w-4" />
-              {categoryCount > 0 && (
+              {activeCount > 0 && (
                 <span className="ml-1 text-xs font-medium tabular-nums">
-                  {categoryCount}
+                  {activeCount}
                 </span>
               )}
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-56">
-            <DropdownMenuLabel>Filter by category</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {categories.length === 0 ? (
-              <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                No categories yet
-              </div>
-            ) : (
-              categories.map((category) => (
-                <DropdownMenuCheckboxItem
-                  key={category.id}
-                  checked={value.categoryIds.includes(category.id)}
-                  onSelect={(e) => e.preventDefault()}
-                  onCheckedChange={(checked) =>
-                    toggleCategory(category.id, checked === true)
-                  }
-                >
-                  {category.name}
-                </DropdownMenuCheckboxItem>
-              ))
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {hasGroupsUi && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size={groupCount === 0 ? "icon" : "default"}
-                aria-label="Filter by group"
-                title="Filter by group"
-              >
-                <Users className="h-4 w-4" />
-                {groupCount > 0 && (
-                  <span className="ml-1 text-xs font-medium tabular-nums">
-                    {groupCount}
-                  </span>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80 p-0">
+            <div className="p-3 space-y-4">
+              <div className="space-y-2">
+                <Label className="text-xs font-medium text-muted-foreground">
+                  Categories
+                </Label>
+                {categories.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No categories yet
+                  </p>
+                ) : (
+                  <div className="max-h-48 overflow-auto space-y-1.5 pr-1">
+                    {categories.map((category) => {
+                      const id = `filter-cat-${category.id}`;
+                      const checked = value.categoryIds.includes(category.id);
+                      return (
+                        <label
+                          key={category.id}
+                          htmlFor={id}
+                          className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
+                        >
+                          <Checkbox
+                            id={id}
+                            checked={checked}
+                            onCheckedChange={(c) =>
+                              toggleCategory(category.id, c === true)
+                            }
+                          />
+                          <span className="truncate">{category.name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
                 )}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-56">
-              <DropdownMenuLabel>Filter by group</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuCheckboxItem
-                checked={value.groupIds.includes(NO_GROUP_FILTER)}
-                onSelect={(e) => e.preventDefault()}
-                onCheckedChange={(checked) =>
-                  toggleGroup(NO_GROUP_FILTER, checked === true)
-                }
-              >
-                <span className="italic text-muted-foreground">No group</span>
-              </DropdownMenuCheckboxItem>
-              {groups!.length === 0 ? (
-                <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                  No groups yet
-                </div>
-              ) : (
-                groups!.map((group) => (
-                  <DropdownMenuCheckboxItem
-                    key={group.id}
-                    checked={value.groupIds.includes(group.id)}
-                    onSelect={(e) => e.preventDefault()}
-                    onCheckedChange={(checked) =>
-                      toggleGroup(group.id, checked === true)
-                    }
-                  >
-                    {group.name}
-                  </DropdownMenuCheckboxItem>
-                ))
+              </div>
+
+              {hasGroupsUi && (
+                <>
+                  <Separator />
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium text-muted-foreground">
+                      Groups
+                    </Label>
+                    <div className="max-h-48 overflow-auto space-y-1.5 pr-1">
+                      <label
+                        htmlFor="filter-grp-none"
+                        className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
+                      >
+                        <Checkbox
+                          id="filter-grp-none"
+                          checked={value.groupIds.includes(NO_GROUP_FILTER)}
+                          onCheckedChange={(c) =>
+                            toggleGroup(NO_GROUP_FILTER, c === true)
+                          }
+                        />
+                        <span className="italic text-muted-foreground">
+                          No group
+                        </span>
+                      </label>
+                      {groups!.length === 0 ? (
+                        <p className="px-1 py-1 text-xs text-muted-foreground">
+                          No groups yet
+                        </p>
+                      ) : (
+                        groups!.map((group) => {
+                          const id = `filter-grp-${group.id}`;
+                          const checked = value.groupIds.includes(group.id);
+                          return (
+                            <label
+                              key={group.id}
+                              htmlFor={id}
+                              className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
+                            >
+                              <Checkbox
+                                id={id}
+                                checked={checked}
+                                onCheckedChange={(c) =>
+                                  toggleGroup(group.id, c === true)
+                                }
+                              />
+                              <span className="truncate">{group.name}</span>
+                            </label>
+                          );
+                        })
+                      )}
+                    </div>
+                  </div>
+                </>
               )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+
+              <Separator />
+              <div className="space-y-2">
+                <Label className="text-xs font-medium text-muted-foreground">
+                  Custom date range
+                </Label>
+                <Calendar
+                  mode="range"
+                  selected={value.dateRange}
+                  onSelect={(range) => onChange({ ...value, dateRange: range })}
+                  numberOfMonths={1}
+                />
+              </div>
+            </div>
+            <Separator />
+            <div className="p-2 flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={reset}
+                disabled={!hasActive}
+              >
+                Clear all
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
 
         <MonthSwitcher
           value={value.dateRange}
           onChange={(range) => onChange({ ...value, dateRange: range })}
         />
 
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="ghost" size="icon" aria-label="Custom date range">
-              <CalendarIcon className="h-4 w-4" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="start">
-            <Calendar
-              mode="range"
-              selected={value.dateRange}
-              onSelect={(range) => onChange({ ...value, dateRange: range })}
-              numberOfMonths={2}
-            />
-          </PopoverContent>
-        </Popover>
-
         {hasActive && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() =>
-              onChange({
-                search: "",
-                categoryIds: [],
-                groupIds: [],
-                dateRange: undefined,
-              })
-            }
-          >
+          <Button variant="ghost" size="sm" onClick={reset}>
             <X className="h-4 w-4" /> Clear
           </Button>
         )}

--- a/src/components/ExpenseFilters.tsx
+++ b/src/components/ExpenseFilters.tsx
@@ -1,14 +1,10 @@
-import { Filter, Search, X } from "lucide-react";
+import { CalendarIcon, Search, X } from "lucide-react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "./ui/button";
 import { Calendar } from "./ui/calendar";
-import { Checkbox } from "./ui/checkbox";
 import { Input } from "./ui/input";
-import { Label } from "./ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { Separator } from "./ui/separator";
 import MonthSwitcher from "./MonthSwitcher";
-import type { Category, Group } from "../types/expense";
 
 export const NO_GROUP_FILTER = "__none__";
 
@@ -20,8 +16,6 @@ export interface ExpenseFiltersState {
 }
 
 interface ExpenseFiltersProps {
-  categories: Category[];
-  groups?: Group[];
   value: ExpenseFiltersState;
   onChange: (next: ExpenseFiltersState) => void;
 }
@@ -33,36 +27,12 @@ const EMPTY: ExpenseFiltersState = {
   dateRange: undefined,
 };
 
-const ExpenseFilters = ({
-  categories,
-  groups,
-  value,
-  onChange,
-}: ExpenseFiltersProps) => {
-  const toggleCategory = (id: string, checked: boolean) => {
-    const next = checked
-      ? [...value.categoryIds, id]
-      : value.categoryIds.filter((x) => x !== id);
-    onChange({ ...value, categoryIds: next });
-  };
-
-  const toggleGroup = (id: string, checked: boolean) => {
-    const next = checked
-      ? [...value.groupIds, id]
-      : value.groupIds.filter((x) => x !== id);
-    onChange({ ...value, groupIds: next });
-  };
-
-  const hasGroupsUi = !!groups;
-
-  const activeCount =
-    value.categoryIds.length +
-    value.groupIds.length +
-    (value.dateRange ? 1 : 0);
-
-  const hasActive = activeCount > 0 || value.search.length > 0;
-
-  const reset = () => onChange(EMPTY);
+const ExpenseFilters = ({ value, onChange }: ExpenseFiltersProps) => {
+  const hasActive =
+    value.search.length > 0 ||
+    value.categoryIds.length > 0 ||
+    value.groupIds.length > 0 ||
+    !!value.dateRange;
 
   return (
     <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
@@ -81,132 +51,20 @@ const ExpenseFilters = ({
           <PopoverTrigger asChild>
             <Button
               variant="outline"
-              size={activeCount === 0 ? "icon" : "default"}
-              aria-label="Filters"
-              title="Filters"
+              size="icon"
+              aria-label="Custom date range"
+              title="Custom date range"
             >
-              <Filter className="h-4 w-4" />
-              {activeCount > 0 && (
-                <span className="ml-1 text-xs font-medium tabular-nums">
-                  {activeCount}
-                </span>
-              )}
+              <CalendarIcon className="h-4 w-4" />
             </Button>
           </PopoverTrigger>
-          <PopoverContent align="start" className="w-80 p-0">
-            <div className="p-3 space-y-4">
-              <div className="space-y-2">
-                <Label className="text-xs font-medium text-muted-foreground">
-                  Categories
-                </Label>
-                {categories.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">
-                    No categories yet
-                  </p>
-                ) : (
-                  <div className="max-h-48 overflow-auto space-y-1.5 pr-1">
-                    {categories.map((category) => {
-                      const id = `filter-cat-${category.id}`;
-                      const checked = value.categoryIds.includes(category.id);
-                      return (
-                        <label
-                          key={category.id}
-                          htmlFor={id}
-                          className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
-                        >
-                          <Checkbox
-                            id={id}
-                            checked={checked}
-                            onCheckedChange={(c) =>
-                              toggleCategory(category.id, c === true)
-                            }
-                          />
-                          <span className="truncate">{category.name}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-
-              {hasGroupsUi && (
-                <>
-                  <Separator />
-                  <div className="space-y-2">
-                    <Label className="text-xs font-medium text-muted-foreground">
-                      Groups
-                    </Label>
-                    <div className="max-h-48 overflow-auto space-y-1.5 pr-1">
-                      <label
-                        htmlFor="filter-grp-none"
-                        className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
-                      >
-                        <Checkbox
-                          id="filter-grp-none"
-                          checked={value.groupIds.includes(NO_GROUP_FILTER)}
-                          onCheckedChange={(c) =>
-                            toggleGroup(NO_GROUP_FILTER, c === true)
-                          }
-                        />
-                        <span className="italic text-muted-foreground">
-                          No group
-                        </span>
-                      </label>
-                      {groups!.length === 0 ? (
-                        <p className="px-1 py-1 text-xs text-muted-foreground">
-                          No groups yet
-                        </p>
-                      ) : (
-                        groups!.map((group) => {
-                          const id = `filter-grp-${group.id}`;
-                          const checked = value.groupIds.includes(group.id);
-                          return (
-                            <label
-                              key={group.id}
-                              htmlFor={id}
-                              className="flex items-center gap-2 text-sm cursor-pointer rounded-sm px-1 py-1 hover:bg-muted"
-                            >
-                              <Checkbox
-                                id={id}
-                                checked={checked}
-                                onCheckedChange={(c) =>
-                                  toggleGroup(group.id, c === true)
-                                }
-                              />
-                              <span className="truncate">{group.name}</span>
-                            </label>
-                          );
-                        })
-                      )}
-                    </div>
-                  </div>
-                </>
-              )}
-
-              <Separator />
-              <div className="space-y-2">
-                <Label className="text-xs font-medium text-muted-foreground">
-                  Custom date range
-                </Label>
-                <Calendar
-                  mode="range"
-                  selected={value.dateRange}
-                  onSelect={(range) => onChange({ ...value, dateRange: range })}
-                  numberOfMonths={1}
-                />
-              </div>
-            </div>
-            <Separator />
-            <div className="p-2 flex justify-end">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={reset}
-                disabled={!hasActive}
-              >
-                Clear all
-              </Button>
-            </div>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="range"
+              selected={value.dateRange}
+              onSelect={(range) => onChange({ ...value, dateRange: range })}
+              numberOfMonths={2}
+            />
           </PopoverContent>
         </Popover>
 
@@ -216,7 +74,11 @@ const ExpenseFilters = ({
         />
 
         {hasActive && (
-          <Button variant="ghost" size="sm" onClick={reset}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onChange(EMPTY)}
+          >
             <X className="h-4 w-4" /> Clear
           </Button>
         )}

--- a/src/components/GroupForm.test.tsx
+++ b/src/components/GroupForm.test.tsx
@@ -44,7 +44,7 @@ describe("GroupForm", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("submits with { name, color, icon } when valid", async () => {
+  it("submits with { name } when valid", async () => {
     const onSubmit = vi.fn();
     const onOpenChange = vi.fn();
     render(
@@ -65,8 +65,6 @@ describe("GroupForm", () => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
     const values = onSubmit.mock.calls[0][0];
-    expect(values.name).toBe("Japan Trip");
-    expect(values.color).toMatch(/^#[0-9a-fA-F]{6}$/);
-    expect(values.icon.length).toBeGreaterThan(0);
+    expect(values).toEqual({ name: "Japan Trip" });
   });
 });

--- a/src/components/GroupForm.tsx
+++ b/src/components/GroupForm.tsx
@@ -1,11 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Check } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { cn } from "../lib/utils";
-import { AVAILABLE_ICONS, CategoryIcon } from "./CategoryIcon";
-import { COLOR_PALETTE } from "../lib/categoryPalette";
 import {
   Dialog,
   DialogContent,
@@ -20,10 +16,6 @@ import { Label } from "./ui/label";
 
 const schema = z.object({
   name: z.string().trim().min(1, "Name is required").max(80),
-  color: z
-    .string()
-    .regex(/^#[0-9a-fA-F]{6}$/, "Color must be a hex value"),
-  icon: z.string().min(1, "Pick an icon"),
 });
 
 export type GroupFormValues = z.infer<typeof schema>;
@@ -39,8 +31,6 @@ interface GroupFormProps {
 
 const DEFAULTS: GroupFormValues = {
   name: "",
-  color: COLOR_PALETTE[0],
-  icon: AVAILABLE_ICONS[0],
 };
 
 const GroupForm = ({
@@ -62,9 +52,6 @@ const GroupForm = ({
     }
   }, [open, initialValue, form]);
 
-  const color = form.watch("color");
-  const icon = form.watch("icon");
-
   const handleSubmit = form.handleSubmit(async (values) => {
     await onSubmit(values);
     onOpenChange(false);
@@ -85,6 +72,7 @@ const GroupForm = ({
             <Input
               id="group-name"
               placeholder="e.g. Japan Trip"
+              autoFocus
               {...form.register("name")}
             />
             {form.formState.errors.name && (
@@ -92,57 +80,6 @@ const GroupForm = ({
                 {form.formState.errors.name.message}
               </p>
             )}
-          </div>
-
-          <div className="space-y-2">
-            <Label>Color</Label>
-            <div className="flex flex-wrap gap-2">
-              {COLOR_PALETTE.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() =>
-                    form.setValue("color", option, { shouldValidate: true })
-                  }
-                  className={cn(
-                    "h-8 w-8 rounded-full border-2 flex items-center justify-center transition",
-                    color === option
-                      ? "border-foreground scale-110"
-                      : "border-transparent hover:scale-105"
-                  )}
-                  style={{ backgroundColor: option }}
-                  aria-label={`Color ${option}`}
-                >
-                  {color === option && (
-                    <Check className="h-4 w-4 text-white drop-shadow" />
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Icon</Label>
-            <div className="grid grid-cols-6 gap-2 sm:grid-cols-9">
-              {AVAILABLE_ICONS.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  onClick={() =>
-                    form.setValue("icon", option, { shouldValidate: true })
-                  }
-                  className={cn(
-                    "h-9 w-9 rounded-md border flex items-center justify-center transition",
-                    icon === option
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-border text-muted-foreground hover:bg-muted"
-                  )}
-                  aria-label={`Icon ${option}`}
-                >
-                  <CategoryIcon name={option} className="h-4 w-4" />
-                </button>
-              ))}
-            </div>
           </div>
         </form>
         <DialogFooter>

--- a/src/features/insights/GroupBreakdownChart.tsx
+++ b/src/features/insights/GroupBreakdownChart.tsx
@@ -5,6 +5,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
+import { COLOR_PALETTE } from "@/lib/categoryPalette";
 import { formatBRL } from "./formatBRL";
 import type { GroupTotal } from "./aggregate";
 
@@ -12,9 +13,11 @@ interface GroupBreakdownChartProps {
   data: GroupTotal[];
 }
 
+const colorFor = (i: number) => COLOR_PALETTE[i % COLOR_PALETTE.length];
+
 const GroupBreakdownChart = ({ data }: GroupBreakdownChartProps) => {
   const config: ChartConfig = Object.fromEntries(
-    data.map((d) => [d.groupId, { label: d.name, color: d.color }])
+    data.map((d, i) => [d.groupId, { label: d.name, color: colorFor(i) }])
   );
   const grand = data.reduce((s, d) => s + d.total, 0);
 
@@ -42,18 +45,18 @@ const GroupBreakdownChart = ({ data }: GroupBreakdownChartProps) => {
             paddingAngle={2}
             stroke="none"
           >
-            {data.map((d) => (
-              <Cell key={d.groupId} fill={d.color} />
+            {data.map((d, i) => (
+              <Cell key={d.groupId} fill={colorFor(i)} />
             ))}
           </Pie>
         </PieChart>
       </ChartContainer>
       <ul className="flex-1 space-y-2 w-full">
-        {data.map((d) => (
+        {data.map((d, i) => (
           <li key={d.groupId} className="flex items-center gap-3 text-sm">
             <span
               className="h-2.5 w-2.5 rounded-[3px] shrink-0"
-              style={{ backgroundColor: d.color }}
+              style={{ backgroundColor: colorFor(i) }}
             />
             <span className="flex-1 truncate">{d.name}</span>
             <span className="font-mono font-medium tabular-nums">

--- a/src/features/insights/aggregate.test.ts
+++ b/src/features/insights/aggregate.test.ts
@@ -31,11 +31,9 @@ const mkExpense = (
   updatedAt: ts,
 });
 
-const grp = (id: string, name: string, color: string): Group => ({
+const grp = (id: string, name: string): Group => ({
   id,
   name,
-  color,
-  icon: "Package",
   order: 0,
   createdAt: ts,
 });
@@ -161,9 +159,9 @@ describe("sumByMonthAndCategory", () => {
 
 describe("sumByGroup", () => {
   const groups = [
-    grp("g1", "Japan", "#111"),
-    grp("g2", "Birthday", "#222"),
-    grp("g3", "Empty", "#333"),
+    grp("g1", "Japan"),
+    grp("g2", "Birthday"),
+    grp("g3", "Empty"),
   ];
 
   it("aggregates and skips ungrouped expenses, sorted by total desc", () => {
@@ -175,8 +173,8 @@ describe("sumByGroup", () => {
     ];
     const rows = sumByGroup(expenses, groups);
     expect(rows).toEqual([
-      { groupId: "g2", name: "Birthday", color: "#222", total: 70, pct: 70 / 120 },
-      { groupId: "g1", name: "Japan", color: "#111", total: 50, pct: 50 / 120 },
+      { groupId: "g2", name: "Birthday", total: 70, pct: 70 / 120 },
+      { groupId: "g1", name: "Japan", total: 50, pct: 50 / 120 },
     ]);
   });
 

--- a/src/features/insights/aggregate.ts
+++ b/src/features/insights/aggregate.ts
@@ -190,7 +190,6 @@ export const sumByCategory = (
 export interface GroupTotal {
   groupId: string;
   name: string;
-  color: string;
   total: number;
   pct: number;
 }
@@ -219,7 +218,6 @@ export const sumByGroup = (
     rows.push({
       groupId: g.id,
       name: g.name,
-      color: g.color,
       total,
       pct: grand > 0 ? total / grand : 0,
     });

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -10,6 +10,7 @@ import {
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import BulkChangeCategoryDialog from "../../components/BulkChangeCategoryDialog";
+import BulkChangeGroupDialog from "../../components/BulkChangeGroupDialog";
 import { DataTable } from "../../components/DataTable";
 import SelectionActionBar from "../../components/SelectionActionBar";
 import ExpenseFilters, {
@@ -42,6 +43,7 @@ import {
   bulkAddExpenses,
   bulkDeleteExpenses,
   bulkUpdateCategory,
+  bulkUpdateGroup,
   deleteExpense,
   updateExpense,
 } from "../../services/expenses";
@@ -77,6 +79,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const [promoting, setPromoting] = useState<Expense | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
+  const [bulkGroupOpen, setBulkGroupOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -112,8 +115,26 @@ const Expenses = ({ uid }: ExpensesProps) => {
         onDelete: (e) => setDeleting(e),
         onPromote: (e) => setPromoting(e),
         includeGroup: groups.length > 0,
+        headerFilters: {
+          categories,
+          groups,
+          categoryIds: filters.categoryIds,
+          groupIds: filters.groupIds,
+          onCategoryIdsChange: (categoryIds) =>
+            setFilters((f) => ({ ...f, categoryIds })),
+          onGroupIdsChange: (groupIds) =>
+            setFilters((f) => ({ ...f, groupIds })),
+        },
       }),
-    [uid, byId, groupsById, groups.length]
+    [
+      uid,
+      byId,
+      groupsById,
+      categories,
+      groups,
+      filters.categoryIds,
+      filters.groupIds,
+    ]
   );
 
   const handleCreate = async (values: ExpenseFormResult) => {
@@ -203,6 +224,16 @@ const Expenses = ({ uid }: ExpensesProps) => {
     setRowSelection({});
   };
 
+  const handleBulkChangeGroup = async (groupId: string | null) => {
+    await bulkUpdateGroup(uid, selectedIds, groupId);
+    toast.success(
+      groupId === null
+        ? `Cleared group on ${selectedIds.length} expense${selectedIds.length === 1 ? "" : "s"}`
+        : `Moved ${selectedIds.length} expense${selectedIds.length === 1 ? "" : "s"} to a new group`
+    );
+    setRowSelection({});
+  };
+
   const handleExport = () => {
     const source =
       selectedIds.length > 0
@@ -241,12 +272,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
   };
 
   const renderToolbar = () => (
-    <ExpenseFilters
-      categories={categories}
-      groups={groups}
-      value={filters}
-      onChange={setFilters}
-    />
+    <ExpenseFilters value={filters} onChange={setFilters} />
   );
 
   return (
@@ -409,6 +435,14 @@ const Expenses = ({ uid }: ExpensesProps) => {
         onConfirm={handleBulkChangeCategory}
       />
 
+      <BulkChangeGroupDialog
+        open={bulkGroupOpen}
+        count={selectedIds.length}
+        groups={groups}
+        onOpenChange={setBulkGroupOpen}
+        onConfirm={handleBulkChangeGroup}
+      />
+
       <ImportDialog
         open={importOpen}
         categories={categories}
@@ -437,6 +471,16 @@ const Expenses = ({ uid }: ExpensesProps) => {
         >
           Change category
         </Button>
+        {groups.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setBulkGroupOpen(true)}
+            className="rounded-full"
+          >
+            Change group
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -115,26 +115,24 @@ const Expenses = ({ uid }: ExpensesProps) => {
         onDelete: (e) => setDeleting(e),
         onPromote: (e) => setPromoting(e),
         includeGroup: groups.length > 0,
-        headerFilters: {
-          categories,
-          groups,
-          categoryIds: filters.categoryIds,
-          groupIds: filters.groupIds,
-          onCategoryIdsChange: (categoryIds) =>
-            setFilters((f) => ({ ...f, categoryIds })),
-          onGroupIdsChange: (groupIds) =>
-            setFilters((f) => ({ ...f, groupIds })),
-        },
       }),
-    [
-      uid,
-      byId,
-      groupsById,
-      categories,
-      groups,
-      filters.categoryIds,
-      filters.groupIds,
-    ]
+    [uid, byId, groupsById, groups.length]
+  );
+
+  const tableMeta = useMemo(
+    () => ({
+      headerFilters: {
+        categories,
+        groups,
+        categoryIds: filters.categoryIds,
+        groupIds: filters.groupIds,
+        onCategoryIdsChange: (categoryIds: string[]) =>
+          setFilters((f) => ({ ...f, categoryIds })),
+        onGroupIdsChange: (groupIds: string[]) =>
+          setFilters((f) => ({ ...f, groupIds })),
+      },
+    }),
+    [categories, groups, filters.categoryIds, filters.groupIds]
   );
 
   const handleCreate = async (values: ExpenseFormResult) => {
@@ -353,6 +351,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
           onRowSelectionChange={setRowSelection}
           getRowId={(row) => row.id}
           renderToolbar={renderToolbar}
+          meta={tableMeta}
         />
       )}
 

--- a/src/pages/Expenses/columns.tsx
+++ b/src/pages/Expenses/columns.tsx
@@ -170,14 +170,7 @@ export const buildExpenseColumns = ({
           ? groupsById.get(row.original.groupId)
           : undefined;
         return g ? (
-          <span className="inline-flex items-center gap-1.5 text-sm">
-            <span
-              className="h-2 w-2 rounded-[2px]"
-              style={{ backgroundColor: g.color }}
-              aria-hidden
-            />
-            <span className="truncate">{g.name}</span>
-          </span>
+          <span className="truncate text-sm">{g.name}</span>
         ) : (
           <span className="text-xs text-muted-foreground">—</span>
         );

--- a/src/pages/Expenses/columns.tsx
+++ b/src/pages/Expenses/columns.tsx
@@ -45,6 +45,10 @@ export interface ColumnHeaderFilters {
   onGroupIdsChange: (ids: string[]) => void;
 }
 
+export interface ExpenseTableMeta {
+  headerFilters?: ColumnHeaderFilters;
+}
+
 export interface BuildExpenseColumnsOptions {
   uid: string;
   byId: Map<string, Category>;
@@ -54,7 +58,6 @@ export interface BuildExpenseColumnsOptions {
   onPromote?: (expense: Expense) => void;
   includeSelect?: boolean;
   includeGroup?: boolean;
-  headerFilters?: ColumnHeaderFilters;
 }
 
 export const buildExpenseColumns = ({
@@ -66,7 +69,6 @@ export const buildExpenseColumns = ({
   onPromote,
   includeSelect = true,
   includeGroup = false,
-  headerFilters,
 }: BuildExpenseColumnsOptions): ColumnDef<Expense>[] => {
   const columns: ColumnDef<Expense>[] = [];
 
@@ -166,20 +168,23 @@ export const buildExpenseColumns = ({
 
   columns.push({
     id: "category",
-    header: headerFilters
-      ? () => (
-          <ColumnFilterDropdown
-            label="Category"
-            options={headerFilters.categories.map((c) => ({
-              value: c.id,
-              label: c.name,
-            }))}
-            values={headerFilters.categoryIds}
-            onChange={headerFilters.onCategoryIdsChange}
-            emptyMessage="No categories yet"
-          />
-        )
-      : "Category",
+    header: ({ table }) => {
+      const meta = table.options.meta as ExpenseTableMeta | undefined;
+      const f = meta?.headerFilters;
+      if (!f) return <span>Category</span>;
+      return (
+        <ColumnFilterDropdown
+          label="Category"
+          options={f.categories.map((c) => ({
+            value: c.id,
+            label: c.name,
+          }))}
+          values={f.categoryIds}
+          onChange={f.onCategoryIdsChange}
+          emptyMessage="No categories yet"
+        />
+      );
+    },
     cell: ({ row }) => (
       <CategoryBadge category={byId.get(row.original.categoryId)} />
     ),
@@ -190,27 +195,30 @@ export const buildExpenseColumns = ({
   if (includeGroup && groupsById) {
     columns.push({
       id: "group",
-      header: headerFilters
-        ? () => (
-            <ColumnFilterDropdown
-              label="Group"
-              options={[
-                {
-                  value: NO_GROUP_FILTER,
-                  label: "No group",
-                  italic: true,
-                },
-                ...headerFilters.groups.map((g) => ({
-                  value: g.id,
-                  label: g.name,
-                })),
-              ]}
-              values={headerFilters.groupIds}
-              onChange={headerFilters.onGroupIdsChange}
-              emptyMessage="No groups yet"
-            />
-          )
-        : "Group",
+      header: ({ table }) => {
+        const meta = table.options.meta as ExpenseTableMeta | undefined;
+        const f = meta?.headerFilters;
+        if (!f) return <span>Group</span>;
+        return (
+          <ColumnFilterDropdown
+            label="Group"
+            options={[
+              {
+                value: NO_GROUP_FILTER,
+                label: "No group",
+                italic: true,
+              },
+              ...f.groups.map((g) => ({
+                value: g.id,
+                label: g.name,
+              })),
+            ]}
+            values={f.groupIds}
+            onChange={f.onGroupIdsChange}
+            emptyMessage="No groups yet"
+          />
+        );
+      },
       cell: ({ row }) => {
         const g = row.original.groupId
           ? groupsById.get(row.original.groupId)

--- a/src/pages/Expenses/columns.tsx
+++ b/src/pages/Expenses/columns.tsx
@@ -9,6 +9,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import CategoryBadge from "../../components/CategoryBadge";
+import ColumnFilterDropdown from "../../components/ColumnFilterDropdown";
+import { NO_GROUP_FILTER } from "../../components/ExpenseFilters";
 import { Button } from "../../components/ui/button";
 import { Checkbox } from "../../components/ui/checkbox";
 import {
@@ -34,6 +36,15 @@ const compareByCategoryName =
     return an.localeCompare(bn);
   };
 
+export interface ColumnHeaderFilters {
+  categories: Category[];
+  groups: Group[];
+  categoryIds: string[];
+  groupIds: string[];
+  onCategoryIdsChange: (ids: string[]) => void;
+  onGroupIdsChange: (ids: string[]) => void;
+}
+
 export interface BuildExpenseColumnsOptions {
   uid: string;
   byId: Map<string, Category>;
@@ -43,6 +54,7 @@ export interface BuildExpenseColumnsOptions {
   onPromote?: (expense: Expense) => void;
   includeSelect?: boolean;
   includeGroup?: boolean;
+  headerFilters?: ColumnHeaderFilters;
 }
 
 export const buildExpenseColumns = ({
@@ -54,6 +66,7 @@ export const buildExpenseColumns = ({
   onPromote,
   includeSelect = true,
   includeGroup = false,
+  headerFilters,
 }: BuildExpenseColumnsOptions): ColumnDef<Expense>[] => {
   const columns: ColumnDef<Expense>[] = [];
 
@@ -153,7 +166,20 @@ export const buildExpenseColumns = ({
 
   columns.push({
     id: "category",
-    header: "Category",
+    header: headerFilters
+      ? () => (
+          <ColumnFilterDropdown
+            label="Category"
+            options={headerFilters.categories.map((c) => ({
+              value: c.id,
+              label: c.name,
+            }))}
+            values={headerFilters.categoryIds}
+            onChange={headerFilters.onCategoryIdsChange}
+            emptyMessage="No categories yet"
+          />
+        )
+      : "Category",
     cell: ({ row }) => (
       <CategoryBadge category={byId.get(row.original.categoryId)} />
     ),
@@ -164,7 +190,27 @@ export const buildExpenseColumns = ({
   if (includeGroup && groupsById) {
     columns.push({
       id: "group",
-      header: "Group",
+      header: headerFilters
+        ? () => (
+            <ColumnFilterDropdown
+              label="Group"
+              options={[
+                {
+                  value: NO_GROUP_FILTER,
+                  label: "No group",
+                  italic: true,
+                },
+                ...headerFilters.groups.map((g) => ({
+                  value: g.id,
+                  label: g.name,
+                })),
+              ]}
+              values={headerFilters.groupIds}
+              onChange={headerFilters.onGroupIdsChange}
+              emptyMessage="No groups yet"
+            />
+          )
+        : "Group",
       cell: ({ row }) => {
         const g = row.original.groupId
           ? groupsById.get(row.original.groupId)

--- a/src/pages/GroupDetail/GroupDetail.tsx
+++ b/src/pages/GroupDetail/GroupDetail.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft, Hash, Pencil, Trash2, Wallet } from "lucide-react";
+import { ArrowLeft, Hash, Pencil, Trash2, Users, Wallet } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
-import { CategoryIcon } from "../../components/CategoryIcon";
 import { DataTable } from "../../components/DataTable";
 import DeleteGroupDialog, {
   type DeleteGroupAction,
@@ -33,7 +32,6 @@ import { sumByCategory } from "../../features/insights/aggregate";
 import { useCategories } from "../../hooks/useCategories";
 import { useExpenses } from "../../hooks/useExpenses";
 import { useGroups } from "../../hooks/useGroups";
-import { contrastingText } from "../../lib/categoryPalette";
 import { deleteExpense, updateExpense } from "../../services/expenses";
 import { bulkUpdateGroup } from "../../services/expenses";
 import { deleteGroup, updateGroup } from "../../services/groups";
@@ -177,14 +175,8 @@ const GroupDetail = ({ uid }: GroupDetailProps) => {
               <ArrowLeft className="h-4 w-4" />
             </Link>
           </Button>
-          <div
-            className="h-10 w-10 shrink-0 rounded-lg flex items-center justify-center"
-            style={{
-              backgroundColor: group.color,
-              color: contrastingText(group.color),
-            }}
-          >
-            <CategoryIcon name={group.icon} className="h-5 w-5" />
+          <div className="h-10 w-10 shrink-0 rounded-lg bg-muted text-muted-foreground flex items-center justify-center">
+            <Users className="h-5 w-5" />
           </div>
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold tracking-tight truncate">
@@ -259,11 +251,7 @@ const GroupDetail = ({ uid }: GroupDetailProps) => {
         open={editOpen}
         title="Edit group"
         submitLabel="Save"
-        initialValue={{
-          name: group.name,
-          color: group.color,
-          icon: group.icon,
-        }}
+        initialValue={{ name: group.name }}
         onOpenChange={setEditOpen}
         onSubmit={handleEditGroup}
       />

--- a/src/pages/Groups/Groups.tsx
+++ b/src/pages/Groups/Groups.tsx
@@ -1,8 +1,7 @@
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { Pencil, Plus, Trash2, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
-import { CategoryIcon } from "../../components/CategoryIcon";
 import DeleteGroupDialog, {
   type DeleteGroupAction,
 } from "../../components/DeleteGroupDialog";
@@ -14,7 +13,6 @@ import { Card, CardContent } from "../../components/ui/card";
 import { Skeleton } from "../../components/ui/skeleton";
 import { useExpenses } from "../../hooks/useExpenses";
 import { useGroups } from "../../hooks/useGroups";
-import { contrastingText } from "../../lib/categoryPalette";
 import { addGroup, deleteGroup, updateGroup } from "../../services/groups";
 import { bulkUpdateGroup } from "../../services/expenses";
 import type { Group } from "../../types/expense";
@@ -126,17 +124,8 @@ const Groups = ({ uid }: GroupsProps) => {
                       className="flex flex-1 items-center gap-4 min-w-0"
                       aria-label={`Open ${group.name}`}
                     >
-                      <div
-                        className="h-12 w-12 shrink-0 rounded-lg flex items-center justify-center"
-                        style={{
-                          backgroundColor: group.color,
-                          color: contrastingText(group.color),
-                        }}
-                      >
-                        <CategoryIcon
-                          name={group.icon}
-                          className="h-5 w-5"
-                        />
+                      <div className="h-12 w-12 shrink-0 rounded-lg bg-muted text-muted-foreground flex items-center justify-center">
+                        <Users className="h-5 w-5" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="font-medium truncate">
@@ -188,15 +177,7 @@ const Groups = ({ uid }: GroupsProps) => {
         open={formOpen}
         title={editing ? "Edit group" : "New group"}
         submitLabel={editing ? "Save" : "Create"}
-        initialValue={
-          editing
-            ? {
-                name: editing.name,
-                color: editing.color,
-                icon: editing.icon,
-              }
-            : undefined
-        }
+        initialValue={editing ? { name: editing.name } : undefined}
         onOpenChange={setFormOpen}
         onSubmit={editing ? handleUpdate : handleCreate}
       />

--- a/src/services/groups.ts
+++ b/src/services/groups.ts
@@ -22,8 +22,6 @@ const groupsQuery = (uid: string) =>
 const mapDoc = (id: string, data: Record<string, unknown>): Group => ({
   id,
   name: data.name as string,
-  color: data.color as string,
-  icon: data.icon as string,
   order: (data.order as number) ?? 0,
   createdAt: data.createdAt as Group["createdAt"],
 });

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -29,8 +29,6 @@ export type CategoryInput = Omit<Category, "id" | "createdAt">;
 export interface Group {
   id: string;
   name: string;
-  color: string;
-  icon: string;
   order: number;
   createdAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- Groups are lightweight tags now (`name` + `order` + `createdAt`). Dropped `color` and `icon` from the Group type, service, form, list card, detail header, Expenses table cell, and `firestore.rules` groups block. `GroupBreakdownChart` rotates through `COLOR_PALETTE` for pie slices.
- `ExpenseFilters` replaces the three separate triggers (Category / Group / Custom-date) with a single **Filters popover** — badge shows the total active-filter count. Toolbar now fits `[Search] [Filters] [MonthSwitcher] [Clear]` on a single row even with both category + group filters active.
- Fixes the `Missing or insufficient permissions` error when creating a group: the old rules block required `color` + `icon`, but more importantly the rules need to be redeployed after merging — run `firebase deploy --only firestore:rules` before shipping the web bundle.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm test` — 62 tests pass (GroupForm + aggregate tests updated for the new shape)
- [x] `firebase deploy --only firestore:rules`
- [x] Manual: create a group "Japan Trip" from `/groups` → no permissions error, card shows neutral Users icon + name
- [x] Manual: `/expenses` toolbar stays on a single row at desktop width; Filters popover renders Categories, Groups (with `No group`), Custom date range, and a `Clear all` footer; badge reflects selection count
- [x] Manual: tag an expense to Japan Trip → row shows just the name in the Group column (no colored dot)
- [x] Manual: `/insights` "By group" card renders with palette-rotated colors