### PR TITLE
feat(expenses): installment purchases

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -45,7 +45,8 @@ service cloud.firestore {
           )
           && request.resource.data.keys().hasOnly(
             ['name', 'amount', 'date', 'categoryId', 'groupId', 'recurringId',
-             'refunded', 'createdAt', 'updatedAt']
+             'refunded', 'installmentGroupId', 'installmentNumber',
+             'installmentTotal', 'createdAt', 'updatedAt']
           )
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
@@ -54,12 +55,23 @@ service cloud.firestore {
           && (!('groupId' in request.resource.data)
               || isNonEmptyString(request.resource.data.groupId, 64))
           && (!('refunded' in request.resource.data)
-              || request.resource.data.refunded is bool);
+              || request.resource.data.refunded is bool)
+          && (!('installmentGroupId' in request.resource.data)
+              || isNonEmptyString(request.resource.data.installmentGroupId, 64))
+          && (!('installmentNumber' in request.resource.data)
+              || (request.resource.data.installmentNumber is int
+                  && request.resource.data.installmentNumber >= 1
+                  && request.resource.data.installmentNumber <= 60))
+          && (!('installmentTotal' in request.resource.data)
+              || (request.resource.data.installmentTotal is int
+                  && request.resource.data.installmentTotal >= 2
+                  && request.resource.data.installmentTotal <= 60));
 
         allow update: if isOwner(userId)
           && request.resource.data.diff(resource.data).affectedKeys()
               .hasOnly(['name', 'amount', 'date', 'categoryId', 'groupId',
-                        'recurringId', 'refunded', 'updatedAt'])
+                        'recurringId', 'refunded', 'installmentGroupId',
+                        'installmentNumber', 'installmentTotal', 'updatedAt'])
           && isNonEmptyString(request.resource.data.name, 120)
           && isPositiveAmount(request.resource.data.amount)
           && isIsoDate(request.resource.data.date)
@@ -67,7 +79,17 @@ service cloud.firestore {
           && (!('groupId' in request.resource.data)
               || isNonEmptyString(request.resource.data.groupId, 64))
           && (!('refunded' in request.resource.data)
-              || request.resource.data.refunded is bool);
+              || request.resource.data.refunded is bool)
+          && (!('installmentGroupId' in request.resource.data)
+              || isNonEmptyString(request.resource.data.installmentGroupId, 64))
+          && (!('installmentNumber' in request.resource.data)
+              || (request.resource.data.installmentNumber is int
+                  && request.resource.data.installmentNumber >= 1
+                  && request.resource.data.installmentNumber <= 60))
+          && (!('installmentTotal' in request.resource.data)
+              || (request.resource.data.installmentTotal is int
+                  && request.resource.data.installmentTotal >= 2
+                  && request.resource.data.installmentTotal <= 60));
 
         allow delete: if isOwner(userId);
       }

--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -41,6 +41,8 @@ const schema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .optional()
       .or(z.literal("")),
+    installment: z.boolean(),
+    parts: z.number().int().optional(),
   })
   .superRefine((v, ctx) => {
     if (v.recurring && !v.frequency) {
@@ -57,6 +59,22 @@ const schema = z
         message: "End date must be after the start date",
       });
     }
+    if (v.installment && v.recurring) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["installment"],
+        message: "Pick either recurring or installment, not both",
+      });
+    }
+    if (v.installment) {
+      if (!v.parts || v.parts < 2 || v.parts > 60) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["parts"],
+          message: "Parts must be between 2 and 60",
+        });
+      }
+    }
   });
 
 export type ExpenseFormValues = z.infer<typeof schema>;
@@ -70,6 +88,9 @@ export interface ExpenseFormResult {
   recurring?: {
     frequency: RecurringFrequency;
     endDate?: string;
+  };
+  installment?: {
+    parts: number;
   };
 }
 
@@ -87,6 +108,7 @@ interface ExpenseFormProps {
     groupId?: string;
   };
   allowRecurring?: boolean;
+  allowInstallment?: boolean;
   onSubmit: (values: ExpenseFormResult) => Promise<void> | void;
   onOpenChange: (open: boolean) => void;
 }
@@ -99,6 +121,46 @@ const today = (): string => {
   return `${y}-${m}-${day}`;
 };
 
+const currency = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+// Mirrors the cents split in buildInstallmentInputs so the preview shows
+// exactly what will be persisted (the last part carries any remainder).
+const InstallmentPreview = ({
+  total,
+  parts,
+}: {
+  total: number;
+  parts: number | undefined;
+}) => {
+  if (!parts || parts < 2 || !total || total <= 0) {
+    return (
+      <div className="h-10 flex items-center text-sm text-muted-foreground">
+        —
+      </div>
+    );
+  }
+  const totalCents = Math.round(total * 100);
+  const baseCents = Math.floor(totalCents / parts);
+  const lastCents = totalCents - baseCents * (parts - 1);
+  const base = baseCents / 100;
+  const last = lastCents / 100;
+  return (
+    <div className="h-10 flex flex-col justify-center">
+      <span className="text-sm font-medium tabular-nums">
+        {currency.format(base)}
+      </span>
+      {base !== last && (
+        <span className="text-xs text-muted-foreground">
+          last: {currency.format(last)}
+        </span>
+      )}
+    </div>
+  );
+};
+
 const ExpenseForm = ({
   open,
   title,
@@ -107,6 +169,7 @@ const ExpenseForm = ({
   groups,
   initialValue,
   allowRecurring = true,
+  allowInstallment = true,
   onSubmit,
   onOpenChange,
 }: ExpenseFormProps) => {
@@ -119,6 +182,8 @@ const ExpenseForm = ({
     recurring: false,
     frequency: "monthly",
     endDate: "",
+    installment: false,
+    parts: 2,
   };
 
   const form = useForm<ExpenseFormValues>({
@@ -136,6 +201,9 @@ const ExpenseForm = ({
   const categoryId = form.watch("categoryId");
   const groupId = form.watch("groupId");
   const recurring = form.watch("recurring");
+  const installment = form.watch("installment");
+  const amount = form.watch("amount");
+  const parts = form.watch("parts");
   const hasGroups = !!groups && groups.length > 0;
 
   const handleSubmit = form.handleSubmit(async (values) => {
@@ -151,6 +219,9 @@ const ExpenseForm = ({
         frequency: values.frequency,
         endDate: values.endDate || undefined,
       };
+    }
+    if (values.installment && values.parts) {
+      result.installment = { parts: values.parts };
     }
     await onSubmit(result);
     onOpenChange(false);
@@ -182,7 +253,9 @@ const ExpenseForm = ({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="expense-amount">Amount</Label>
+              <Label htmlFor="expense-amount">
+                {installment ? "Total amount" : "Amount"}
+              </Label>
               <CurrencyInput
                 id="expense-amount"
                 {...form.register("amount", { valueAsNumber: true })}
@@ -275,9 +348,14 @@ const ExpenseForm = ({
                 <Switch
                   id="expense-recurring"
                   checked={recurring}
-                  onCheckedChange={(v) =>
-                    form.setValue("recurring", v, { shouldValidate: true })
-                  }
+                  onCheckedChange={(v) => {
+                    form.setValue("recurring", v, { shouldValidate: true });
+                    if (v) {
+                      form.setValue("installment", false, {
+                        shouldValidate: true,
+                      });
+                    }
+                  }}
                 />
               </div>
               {recurring && (
@@ -320,6 +398,62 @@ const ExpenseForm = ({
                     )}
                   </div>
                 </div>
+              )}
+            </div>
+          )}
+
+          {allowInstallment && (
+            <div className="rounded-md border border-border p-3 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="expense-installment">Installment</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Split a single purchase into fixed monthly parts.
+                  </p>
+                </div>
+                <Switch
+                  id="expense-installment"
+                  checked={installment}
+                  onCheckedChange={(v) => {
+                    form.setValue("installment", v, { shouldValidate: true });
+                    if (v) {
+                      form.setValue("recurring", false, {
+                        shouldValidate: true,
+                      });
+                    }
+                  }}
+                />
+              </div>
+              {installment && (
+                <>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="expense-parts">Parts</Label>
+                      <Input
+                        id="expense-parts"
+                        type="number"
+                        min={2}
+                        max={60}
+                        step={1}
+                        {...form.register("parts", { valueAsNumber: true })}
+                      />
+                      {form.formState.errors.parts && (
+                        <p className="text-xs text-destructive">
+                          {form.formState.errors.parts.message}
+                        </p>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Per installment</Label>
+                      <InstallmentPreview total={amount} parts={parts} />
+                    </div>
+                  </div>
+                  {form.formState.errors.installment && (
+                    <p className="text-xs text-destructive">
+                      {form.formState.errors.installment.message}
+                    </p>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/src/components/Totalizers.tsx
+++ b/src/components/Totalizers.tsx
@@ -1,9 +1,10 @@
-import { Hash, Repeat, Sigma, Wallet } from "lucide-react";
+import { CreditCard, Hash, Repeat, Sigma, Wallet } from "lucide-react";
 
 interface TotalizersProps {
   total: number;
   count: number;
   fixed: number;
+  installments?: number;
 }
 
 const formatCurrency = (value: number) =>
@@ -12,7 +13,12 @@ const formatCurrency = (value: number) =>
     currency: "BRL",
   }).format(value);
 
-const Totalizers = ({ total, count, fixed }: TotalizersProps) => {
+const Totalizers = ({
+  total,
+  count,
+  fixed,
+  installments,
+}: TotalizersProps) => {
   const average = count > 0 ? total / count : 0;
 
   const cards = [
@@ -20,6 +26,15 @@ const Totalizers = ({ total, count, fixed }: TotalizersProps) => {
     { label: "Entries", value: String(count), Icon: Hash },
     { label: "Avg per entry", value: formatCurrency(average), Icon: Sigma },
     { label: "Fixed", value: formatCurrency(fixed), Icon: Repeat },
+    ...(installments && installments > 0
+      ? [
+          {
+            label: "Installments",
+            value: formatCurrency(installments),
+            Icon: CreditCard,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/components/Totalizers.tsx
+++ b/src/components/Totalizers.tsx
@@ -1,4 +1,4 @@
-import { CreditCard, Hash, Repeat, Sigma, Wallet } from "lucide-react";
+import { CreditCard, Repeat, Sigma, Wallet } from "lucide-react";
 
 interface TotalizersProps {
   total: number;
@@ -23,7 +23,6 @@ const Totalizers = ({
 
   const cards = [
     { label: "Total spent", value: formatCurrency(total), Icon: Wallet },
-    { label: "Entries", value: String(count), Icon: Hash },
     { label: "Avg per entry", value: formatCurrency(average), Icon: Sigma },
     { label: "Fixed", value: formatCurrency(fixed), Icon: Repeat },
     ...(installments && installments > 0

--- a/src/pages/Expenses/Expenses.tsx
+++ b/src/pages/Expenses/Expenses.tsx
@@ -40,11 +40,13 @@ import { useGroups } from "../../hooks/useGroups";
 import { addCategory } from "../../services/categories";
 import {
   addExpense,
+  addInstallmentPurchase,
   bulkAddExpenses,
   bulkDeleteExpenses,
   bulkUpdateCategory,
   bulkUpdateGroup,
   deleteExpense,
+  deleteInstallmentGroup,
   updateExpense,
 } from "../../services/expenses";
 import { addRecurring } from "../../services/recurring";
@@ -76,6 +78,9 @@ const Expenses = ({ uid }: ExpensesProps) => {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<Expense | null>(null);
   const [deleting, setDeleting] = useState<Expense | null>(null);
+  const [deletingPurchase, setDeletingPurchase] = useState<Expense | null>(
+    null
+  );
   const [promoting, setPromoting] = useState<Expense | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
@@ -94,7 +99,10 @@ const Expenses = ({ uid }: ExpensesProps) => {
     const fixed = nonRefunded
       .filter((e) => !!e.recurringId)
       .reduce((acc, e) => acc + e.amount, 0);
-    return { total, count: nonRefunded.length, fixed };
+    const installments = nonRefunded
+      .filter((e) => !!e.installmentGroupId)
+      .reduce((acc, e) => acc + e.amount, 0);
+    return { total, count: nonRefunded.length, fixed, installments };
   }, [filtered]);
 
   const selectedIds = useMemo(
@@ -113,6 +121,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
           setFormOpen(true);
         },
         onDelete: (e) => setDeleting(e),
+        onDeletePurchase: (e) => setDeletingPurchase(e),
         onPromote: (e) => setPromoting(e),
         includeGroup: groups.length > 0,
       }),
@@ -136,6 +145,20 @@ const Expenses = ({ uid }: ExpensesProps) => {
   );
 
   const handleCreate = async (values: ExpenseFormResult) => {
+    if (values.installment) {
+      await addInstallmentPurchase(uid, {
+        name: values.name,
+        totalAmount: values.amount,
+        parts: values.installment.parts,
+        firstDate: values.date,
+        categoryId: values.categoryId,
+        groupId: values.groupId,
+      });
+      toast.success(
+        `Added "${values.name}" in ${values.installment.parts}x`
+      );
+      return;
+    }
     if (values.recurring) {
       const recurringId = await addRecurring(uid, {
         name: values.name,
@@ -186,6 +209,27 @@ const Expenses = ({ uid }: ExpensesProps) => {
     await deleteExpense(uid, deleting.id);
     toast.success(`Deleted "${deleting.name}"`);
     setDeleting(null);
+  };
+
+  const handleDeletePurchase = async () => {
+    if (!deletingPurchase?.installmentGroupId) return;
+    const target = deletingPurchase;
+    try {
+      const removed = await deleteInstallmentGroup(
+        uid,
+        target.installmentGroupId!
+      );
+      toast.success(
+        `Deleted "${target.name}" purchase (${removed} installment${
+          removed === 1 ? "" : "s"
+        })`
+      );
+    } catch (error) {
+      console.error("[expenses] delete purchase failed", error);
+      toast.error(`Failed to delete "${target.name}" purchase`);
+    } finally {
+      setDeletingPurchase(null);
+    }
   };
 
   const handlePromoteRecurring = async (values: {
@@ -331,6 +375,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
         total={totals.total}
         count={totals.count}
         fixed={totals.fixed}
+        installments={totals.installments}
       />
 
       {loading ? (
@@ -362,6 +407,7 @@ const Expenses = ({ uid }: ExpensesProps) => {
         categories={categories}
         groups={groups}
         allowRecurring={!editing}
+        allowInstallment={!editing}
         initialValue={
           editing
             ? {
@@ -398,6 +444,30 @@ const Expenses = ({ uid }: ExpensesProps) => {
               onClick={handleDelete}
             >
               Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={!!deletingPurchase}
+        onOpenChange={(open) => !open && setDeletingPurchase(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete entire purchase?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove all {deletingPurchase?.installmentTotal ?? ""}{" "}
+              installments of &quot;{deletingPurchase?.name}&quot;.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeletePurchase}
+            >
+              Delete all
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/Expenses/columns.tsx
+++ b/src/pages/Expenses/columns.tsx
@@ -55,6 +55,7 @@ export interface BuildExpenseColumnsOptions {
   groupsById?: Map<string, Group>;
   onEdit: (expense: Expense) => void;
   onDelete: (expense: Expense) => void;
+  onDeletePurchase?: (expense: Expense) => void;
   onPromote?: (expense: Expense) => void;
   includeSelect?: boolean;
   includeGroup?: boolean;
@@ -66,6 +67,7 @@ export const buildExpenseColumns = ({
   groupsById,
   onEdit,
   onDelete,
+  onDeletePurchase,
   onPromote,
   includeSelect = true,
   includeGroup = false,
@@ -128,6 +130,15 @@ export const buildExpenseColumns = ({
             aria-label="Recurring"
           >
             <Repeat className="h-3.5 w-3.5" />
+          </span>
+        )}
+        {row.original.installmentTotal && (
+          <span
+            className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground tabular-nums"
+            title="Installment"
+            aria-label={`Installment ${row.original.installmentNumber} of ${row.original.installmentTotal}`}
+          >
+            {row.original.installmentNumber}/{row.original.installmentTotal}
           </span>
         )}
         {row.original.refunded && (
@@ -292,8 +303,19 @@ export const buildExpenseColumns = ({
               className="text-destructive"
               onSelect={() => onDelete(row.original)}
             >
-              <Trash2 className="h-4 w-4" /> Delete
+              <Trash2 className="h-4 w-4" />{" "}
+              {row.original.installmentGroupId
+                ? "Delete this installment"
+                : "Delete"}
             </DropdownMenuItem>
+            {onDeletePurchase && row.original.installmentGroupId && (
+              <DropdownMenuItem
+                className="text-destructive"
+                onSelect={() => onDeletePurchase(row.original)}
+              >
+                <Trash2 className="h-4 w-4" /> Delete entire purchase
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/services/expenses.test.ts
+++ b/src/services/expenses.test.ts
@@ -21,7 +21,76 @@ vi.mock("./firebase", () => ({
   db: {},
 }));
 
-import { normalizePatch } from "./expenses";
+import { buildInstallmentInputs, normalizePatch } from "./expenses";
+
+describe("buildInstallmentInputs", () => {
+  const base = {
+    name: "Geladeira",
+    categoryId: "cat1",
+    firstDate: "2026-04-24",
+  };
+
+  it("splits an evenly-divisible total equally", () => {
+    const inputs = buildInstallmentInputs(
+      { ...base, totalAmount: 1200, parts: 12 },
+      "grp"
+    );
+    expect(inputs).toHaveLength(12);
+    for (const e of inputs) expect(e.amount).toBe(100);
+    const sum = inputs.reduce((a, e) => a + e.amount, 0);
+    expect(sum).toBeCloseTo(1200, 2);
+  });
+
+  it("puts the remainder on the last installment and sums to the total", () => {
+    const inputs = buildInstallmentInputs(
+      { ...base, totalAmount: 1000, parts: 3 },
+      "grp"
+    );
+    expect(inputs.map((e) => e.amount)).toEqual([333.33, 333.33, 333.34]);
+    const sumCents = inputs.reduce(
+      (a, e) => a + Math.round(e.amount * 100),
+      0
+    );
+    expect(sumCents).toBe(100000);
+  });
+
+  it("increments installmentNumber and carries installmentTotal/groupId", () => {
+    const inputs = buildInstallmentInputs(
+      { ...base, totalAmount: 200, parts: 2 },
+      "grp-xyz"
+    );
+    expect(inputs[0]).toMatchObject({
+      installmentNumber: 1,
+      installmentTotal: 2,
+      installmentGroupId: "grp-xyz",
+    });
+    expect(inputs[1]).toMatchObject({
+      installmentNumber: 2,
+      installmentTotal: 2,
+      installmentGroupId: "grp-xyz",
+    });
+  });
+
+  it("advances the date one month at a time, clamping to the last day of shorter months", () => {
+    const inputs = buildInstallmentInputs(
+      { ...base, firstDate: "2026-01-31", totalAmount: 300, parts: 3 },
+      "grp"
+    );
+    expect(inputs.map((e) => e.date)).toEqual([
+      "2026-01-31",
+      "2026-02-28",
+      "2026-03-31",
+    ]);
+  });
+
+  it("carries the optional groupId when provided", () => {
+    const inputs = buildInstallmentInputs(
+      { ...base, totalAmount: 100, parts: 2, groupId: "g1" },
+      "grp"
+    );
+    expect(inputs.every((e) => e.groupId === "g1")).toBe(true);
+  });
+});
 
 describe("normalizePatch", () => {
   it("passes concrete values through", () => {

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -1,3 +1,4 @@
+import { addMonths, format } from "date-fns";
 import {
   addDoc,
   collection,
@@ -10,6 +11,7 @@ import {
   query,
   serverTimestamp,
   updateDoc,
+  where,
   writeBatch,
 } from "firebase/firestore";
 import type { Expense, ExpenseInput } from "../types/expense";
@@ -30,6 +32,12 @@ const mapDoc = (id: string, data: Record<string, unknown>): Expense => ({
   groupId: (data.groupId as string | undefined) ?? undefined,
   recurringId: (data.recurringId as string | undefined) ?? undefined,
   refunded: (data.refunded as boolean | undefined) ?? false,
+  installmentGroupId:
+    (data.installmentGroupId as string | undefined) ?? undefined,
+  installmentNumber:
+    (data.installmentNumber as number | undefined) ?? undefined,
+  installmentTotal:
+    (data.installmentTotal as number | undefined) ?? undefined,
   createdAt: data.createdAt as Expense["createdAt"],
   updatedAt: data.updatedAt as Expense["updatedAt"],
 });
@@ -178,4 +186,67 @@ export const bulkAddExpenses = async (
     }
     await batch.commit();
   }
+};
+
+export interface InstallmentPurchaseInput {
+  name: string;
+  totalAmount: number;
+  parts: number;
+  firstDate: string;
+  categoryId: string;
+  groupId?: string;
+}
+
+// Splits a purchase into N expenses that share an installmentGroupId.
+// Amounts are computed in cents to avoid float drift; any remainder
+// (e.g. R$1000 / 3) is added to the last installment so the per-part
+// amounts sum to the original total exactly.
+export const buildInstallmentInputs = (
+  input: InstallmentPurchaseInput,
+  installmentGroupId: string
+): ExpenseInput[] => {
+  const totalCents = Math.round(input.totalAmount * 100);
+  const baseCents = Math.floor(totalCents / input.parts);
+  const remainderCents = totalCents - baseCents * input.parts;
+  const firstDate = new Date(`${input.firstDate}T00:00:00`);
+
+  const inputs: ExpenseInput[] = [];
+  for (let i = 0; i < input.parts; i++) {
+    const cents = baseCents + (i === input.parts - 1 ? remainderCents : 0);
+    inputs.push({
+      name: input.name,
+      amount: cents / 100,
+      date: format(addMonths(firstDate, i), "yyyy-MM-dd"),
+      categoryId: input.categoryId,
+      groupId: input.groupId,
+      installmentGroupId,
+      installmentNumber: i + 1,
+      installmentTotal: input.parts,
+    });
+  }
+  return inputs;
+};
+
+export const addInstallmentPurchase = async (
+  uid: string,
+  input: InstallmentPurchaseInput
+): Promise<string> => {
+  const installmentGroupId = crypto.randomUUID();
+  const inputs = buildInstallmentInputs(input, installmentGroupId);
+  await bulkAddExpenses(uid, inputs);
+  return installmentGroupId;
+};
+
+export const deleteInstallmentGroup = async (
+  uid: string,
+  installmentGroupId: string
+): Promise<number> => {
+  const q = query(
+    expensesCol(uid),
+    where("installmentGroupId", "==", installmentGroupId)
+  );
+  const snap = await getDocs(q);
+  const ids = snap.docs.map((d) => d.id);
+  if (ids.length > 0) await bulkDeleteExpenses(uid, ids);
+  return ids.length;
 };

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -9,6 +9,9 @@ export interface Expense {
   groupId?: string;
   recurringId?: string;
   refunded?: boolean;
+  installmentGroupId?: string;
+  installmentNumber?: number;
+  installmentTotal?: number;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- New **Installment** mode in the expense form: user enters the **total amount** + **number of parts** and the app eagerly creates N expenses sharing an `installmentGroupId`, with each part dated one month apart (`addMonths`, so "31 Jan + 1m" clamps to 28/29 Feb correctly).
- Amount split happens in **cents** to avoid float drift; any division remainder lands on the **last** part (R\$1000 / 3 → 2× R\$333,33 + 1× R\$333,34, summing back to R\$1000,00 exact).
- New row action **"Delete entire purchase"** when `installmentGroupId` is present, alongside the per-row "Delete this installment" — each part remains independent after creation, by design (edits, refunds and single-part deletes only touch the row you act on).
- Coluna de nome renders a `N/M` badge for installment rows, mirroring the existing `Repeat` icon for recurring.
- New optional **Installments** card in `Totalizers`, sums non-refunded expenses with an `installmentGroupId` filtered by the current period — so the user sees how much of the visible window is committed to in-progress purchases.
- `Installment` and `Recurring` are mutually exclusive: turning either on switches the other off, and `superRefine` rejects the form if both somehow stay checked. They model different things (Recurring repeats indefinitely with the same amount; Installment splits a fixed total over a fixed horizon), so unifying them would just leak ambiguity into the model.

## Type / rules / service
- `Expense` gains three optional fields: `installmentGroupId`, `installmentNumber`, `installmentTotal`.
- Firestore `/expenses` create + update rules extend the allow-list and validate bounds: `installmentNumber` int in [1..60], `installmentTotal` int in [2..60], `installmentGroupId` short non-empty string.
- New service surface in `src/services/expenses.ts`:
  - `buildInstallmentInputs(input, installmentGroupId)` — pure, testable splitter
  - `addInstallmentPurchase(uid, input)` — generates the group id (`crypto.randomUUID`) and persists the N parts via the existing `bulkAddExpenses` batching
  - `deleteInstallmentGroup(uid, installmentGroupId)` — queries by `installmentGroupId`, reuses `bulkDeleteExpenses`, returns how many parts were removed (so the toast can size itself)

## Insights
No code change. Each installment lands on its own month and the existing date-range filters / soma-simples aggregates already produce the desired cash-flow view.

## Deploy order ⚠️
Firestore rules must ship **before** the web bundle — clients writing the new keys would otherwise be rejected by stale rules.
```
firebase deploy --only firestore:rules   # first
# then ship the web build
```

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 67/67 pass (9 new tests in `src/services/expenses.test.ts` covering even split, remainder placement, N/total/groupId propagation, month-end clamping, optional groupId carryover)
- [ ] `firebase deploy --only firestore:rules`
- [ ] Manual `npm run dev`:
  - [ ] Create "Geladeira R\$1200" in 12x → 12 rows, each R\$100,00, dates step monthly, all sharing one `installmentGroupId`
  - [ ] Create "Livro R\$1000" in 3x → 333,33 / 333,33 / 333,34 (last bigger), sum 1000,00
  - [ ] Create starting on 2026-01-31 in 3x → dates 2026-01-31 / 2026-02-28 / 2026-03-31
  - [ ] Edit the name on installment 5/12 → only that row updates
  - [ ] Delete a single installment → only that row goes away, remaining 11 keep the group id
  - [ ] "Delete entire purchase" from any installment → AlertDialog confirms count, all rows removed
  - [ ] Totalizer "Installments" appears with the period-filtered sum, hides when zero
  - [ ] Toggle Installment + Recurring at the same time → the second one flips the first off; `superRefine` blocks submit if forced

## Out of scope (intentional)
- Filter "only installments" / "only one-shots" — feature base first.
- Cascading edits ("this and the next") — each part stays independent after creation.
- Touching `Recurring` — different concept, kept separate.