### PR TITLE
fix(deploy): SPA rewrite so client routes survive a refresh

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Refresh em rotas client-side (ex: `/expenses`) retornava `404: NOT_FOUND` no Vercel porque não existe arquivo estático naquele caminho.
- Adiciona `vercel.json` com rewrite `/(.*)` → `/index.html` para que o Vercel sempre entregue o `index.html` e o React Router assuma o roteamento.

## Test plan
- [x] Após o deploy de preview, acessar `https://<preview>/expenses` direto pela URL e confirmar que carrega a página de expenses (sem 404).
- [x] Dar refresh (Cmd+R) em `/expenses`, `/groups` e qualquer subrota e confirmar que mantém a página atual.
- [x] Acessar `/` e confirmar que a home segue funcionando normalmente.